### PR TITLE
Add message receiver HTTP trigger

### DIFF
--- a/source/GreenEnergyHub.TimeSeries/GreenEnergyHub.TimeSeries.sln
+++ b/source/GreenEnergyHub.TimeSeries/GreenEnergyHub.TimeSeries.sln
@@ -40,6 +40,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GreenEnergyHub.Json", "..\S
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GreenEnergyHub.TestHelpers", "..\Shared\GreenEnergyHub\source\GreenEnergyHub.TestHelpers\GreenEnergyHub.TestHelpers.csproj", "{0C63BAFE-D498-4B77-9EFE-CA885FD7587C}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GreenEnergyHub.TimeSeries.MessageReceiver", "source\GreenEnergyHub.TimeSeries.MessageReceiver\GreenEnergyHub.TimeSeries.MessageReceiver.csproj", "{5B29036A-F1C7-43FE-B8AA-C1A334B9E5CF}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -82,6 +84,10 @@ Global
 		{0C63BAFE-D498-4B77-9EFE-CA885FD7587C}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{0C63BAFE-D498-4B77-9EFE-CA885FD7587C}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{0C63BAFE-D498-4B77-9EFE-CA885FD7587C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5B29036A-F1C7-43FE-B8AA-C1A334B9E5CF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5B29036A-F1C7-43FE-B8AA-C1A334B9E5CF}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5B29036A-F1C7-43FE-B8AA-C1A334B9E5CF}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5B29036A-F1C7-43FE-B8AA-C1A334B9E5CF}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -91,9 +97,10 @@ Global
 		{BEE26AFC-4E8A-4005-B84C-487D4487423F} = {8E1E68E2-7F6B-4FA3-8B97-80CA59BDB57C}
 		{0C63BAFE-D498-4B77-9EFE-CA885FD7587C} = {8E1E68E2-7F6B-4FA3-8B97-80CA59BDB57C}
 		{BB933926-FE46-44A3-BD3A-A4C2CFBC6FA2} = {EFB093C9-3F44-4B27-B377-A6CD9B25AFEC}
-		{2780409A-4228-4856-ABB4-266CFD1811A4} = {EFB093C9-3F44-4B27-B377-A6CD9B25AFEC}		
+		{2780409A-4228-4856-ABB4-266CFD1811A4} = {EFB093C9-3F44-4B27-B377-A6CD9B25AFEC}
+		{5B29036A-F1C7-43FE-B8AA-C1A334B9E5CF} = {0F6D6178-E28A-445D-99A8-7CABDC3EC55A}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {8CC9992B-81F9-4F47-8F02-D9D126AC403B}
-	EndGlobalSection	
+	EndGlobalSection
 EndGlobal

--- a/source/GreenEnergyHub.TimeSeries/source/GreenEnergyHub.TimeSeries.Domain/GreenEnergyHub.TimeSeries.Domain.csproj
+++ b/source/GreenEnergyHub.TimeSeries/source/GreenEnergyHub.TimeSeries.Domain/GreenEnergyHub.TimeSeries.Domain.csproj
@@ -24,4 +24,8 @@ limitations under the License.
         <LangVersion>9</LangVersion>
     </PropertyGroup>
 
+    <ItemGroup>
+      <PackageReference Include="NodaTime" Version="3.0.5" />
+    </ItemGroup>
+
 </Project>

--- a/source/GreenEnergyHub.TimeSeries/source/GreenEnergyHub.TimeSeries.Infrastructure/Messaging/CorrelationContext.cs
+++ b/source/GreenEnergyHub.TimeSeries/source/GreenEnergyHub.TimeSeries.Infrastructure/Messaging/CorrelationContext.cs
@@ -1,0 +1,26 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace GreenEnergyHub.TimeSeries.Infrastructure.Messaging
+{
+    public class CorrelationContext : ICorrelationContext
+    {
+        public CorrelationContext()
+        {
+            CorrelationId = string.Empty;
+        }
+
+        public string CorrelationId { get; set; }
+    }
+}

--- a/source/GreenEnergyHub.TimeSeries/source/GreenEnergyHub.TimeSeries.Infrastructure/Messaging/ICorrelationContext.cs
+++ b/source/GreenEnergyHub.TimeSeries/source/GreenEnergyHub.TimeSeries.Infrastructure/Messaging/ICorrelationContext.cs
@@ -1,0 +1,27 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace GreenEnergyHub.TimeSeries.Infrastructure.Messaging
+{
+    /// <summary>
+    /// Interface for class exposing a correlation context
+    /// </summary>
+    public interface ICorrelationContext
+    {
+        /// <summary>
+        /// The correlation ID which can be used to link different operations together
+        /// </summary>
+        string CorrelationId { get; set; }
+    }
+}

--- a/source/GreenEnergyHub.TimeSeries/source/GreenEnergyHub.TimeSeries.MessageReceiver/GreenEnergyHub.TimeSeries.MessageReceiver.csproj
+++ b/source/GreenEnergyHub.TimeSeries/source/GreenEnergyHub.TimeSeries.MessageReceiver/GreenEnergyHub.TimeSeries.MessageReceiver.csproj
@@ -1,0 +1,45 @@
+<!--
+Copyright 2020 Energinet DataHub A/S
+
+Licensed under the Apache License, Version 2.0 (the "License2");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <AzureFunctionsVersion>v3</AzureFunctionsVersion>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Azure.Functions.Extensions" Version="1.1.0" />
+    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.EventHubs" Version="4.2.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.1.14" />
+    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="3.0.12" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Update="host.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="local.settings.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <CopyToPublishDirectory>Never</CopyToPublishDirectory>
+    </None>
+    <None Update="local.settings.sample.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <CopyToPublishDirectory>Never</CopyToPublishDirectory>
+    </None>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\GreenEnergyHub.TimeSeries.Application\GreenEnergyHub.TimeSeries.Application.csproj" />
+    <ProjectReference Include="..\GreenEnergyHub.TimeSeries.Domain\GreenEnergyHub.TimeSeries.Domain.csproj" />
+    <ProjectReference Include="..\GreenEnergyHub.TimeSeries.Infrastructure\GreenEnergyHub.TimeSeries.Infrastructure.csproj" />
+  </ItemGroup>
+</Project>

--- a/source/GreenEnergyHub.TimeSeries/source/GreenEnergyHub.TimeSeries.MessageReceiver/HealthStatus.cs
+++ b/source/GreenEnergyHub.TimeSeries/source/GreenEnergyHub.TimeSeries.MessageReceiver/HealthStatus.cs
@@ -1,0 +1,47 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Azure.WebJobs;
+using Microsoft.Azure.WebJobs.Extensions.Http;
+using Microsoft.Extensions.Logging;
+
+namespace GreenEnergyHub.TimeSeries.MessageReceiver
+{
+    public static class HealthStatus
+    {
+        /// <summary>
+        /// HTTP GET endpoint that can be used to monitor the health of the function app.
+        /// </summary>
+        [FunctionName(nameof(HealthStatus))]
+        public static Task<IActionResult> RunAsync(
+            [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = null)] HttpRequest req,
+            ILogger log)
+        {
+            log.LogInformation("Health Status API invoked");
+            log.LogDebug("Workaround for unused method argument", req);
+
+            /* Consider checking access to used Service Bus topics and other health checks */
+
+            var status = new
+            {
+                FunctionAppIsAlive = true,
+            };
+
+            return Task.FromResult<IActionResult>(new JsonResult(status));
+        }
+    }
+}

--- a/source/GreenEnergyHub.TimeSeries/source/GreenEnergyHub.TimeSeries.MessageReceiver/Properties/serviceDependencies.json
+++ b/source/GreenEnergyHub.TimeSeries/source/GreenEnergyHub.TimeSeries.MessageReceiver/Properties/serviceDependencies.json
@@ -1,0 +1,11 @@
+{
+  "dependencies": {
+    "appInsights1": {
+      "type": "appInsights"
+    },
+    "storage1": {
+      "type": "storage",
+      "connectionId": "AzureWebJobsStorage"
+    }
+  }
+}

--- a/source/GreenEnergyHub.TimeSeries/source/GreenEnergyHub.TimeSeries.MessageReceiver/Properties/serviceDependencies.local.json
+++ b/source/GreenEnergyHub.TimeSeries/source/GreenEnergyHub.TimeSeries.MessageReceiver/Properties/serviceDependencies.local.json
@@ -1,0 +1,11 @@
+{
+  "dependencies": {
+    "appInsights1": {
+      "type": "appInsights.sdk"
+    },
+    "storage1": {
+      "type": "storage.emulator",
+      "connectionId": "AzureWebJobsStorage"
+    }
+  }
+}

--- a/source/GreenEnergyHub.TimeSeries/source/GreenEnergyHub.TimeSeries.MessageReceiver/Startup.cs
+++ b/source/GreenEnergyHub.TimeSeries/source/GreenEnergyHub.TimeSeries.MessageReceiver/Startup.cs
@@ -1,0 +1,41 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Diagnostics.CodeAnalysis;
+using GreenEnergyHub.TimeSeries.Infrastructure.Messaging;
+using GreenEnergyHub.TimeSeries.MessageReceiver;
+using Microsoft.Azure.Functions.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection;
+using NodaTime;
+
+[assembly: FunctionsStartup(typeof(Startup))]
+
+namespace GreenEnergyHub.TimeSeries.MessageReceiver
+{
+    public class Startup : FunctionsStartup
+    {
+        public override void Configure([NotNull] IFunctionsHostBuilder builder)
+        {
+            builder.Services.AddScoped(typeof(IClock), _ => SystemClock.Instance);
+
+            ConfigureMessaging(builder);
+        }
+
+        private static void ConfigureMessaging(IFunctionsHostBuilder builder)
+        {
+            // TODO: This line should be replaced by the MessageRegistration once a need for more messaging arise
+            builder.Services.AddScoped<ICorrelationContext, CorrelationContext>();
+        }
+    }
+}

--- a/source/GreenEnergyHub.TimeSeries/source/GreenEnergyHub.TimeSeries.MessageReceiver/TimeSeriesHttpTrigger.cs
+++ b/source/GreenEnergyHub.TimeSeries/source/GreenEnergyHub.TimeSeries.MessageReceiver/TimeSeriesHttpTrigger.cs
@@ -1,0 +1,59 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Diagnostics.CodeAnalysis;
+using System.Threading.Tasks;
+using GreenEnergyHub.TimeSeries.Infrastructure.Messaging;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Azure.WebJobs;
+using Microsoft.Azure.WebJobs.Extensions.Http;
+using Microsoft.Extensions.Logging;
+
+namespace GreenEnergyHub.TimeSeries.MessageReceiver
+{
+    public class TimeSeriesHttpTrigger
+    {
+        /// <summary>
+        /// The name of the function.
+        /// Function name affects the URL and thus possibly dependent infrastructure.
+        /// </summary>
+        private const string FunctionName = "TimeSeriesHttpTrigger";
+        private readonly ICorrelationContext _correlationContext;
+
+        public TimeSeriesHttpTrigger(ICorrelationContext correlationContext)
+        {
+            _correlationContext = correlationContext;
+        }
+
+        [FunctionName(FunctionName)]
+        public async Task<IActionResult> RunAsync(
+            [HttpTrigger(AuthorizationLevel.Anonymous, "post", Route = null)]
+            [NotNull] HttpRequest req,
+            [NotNull] ExecutionContext context,
+            ILogger log)
+        {
+            log.LogInformation("Function {FunctionName} started to process a request with a body of size {SizeOfBody}", FunctionName, req.Body.Length);
+
+            SetupCorrelationContext(context);
+
+            return await Task.FromResult(new OkResult()).ConfigureAwait(false);
+        }
+
+        private void SetupCorrelationContext(ExecutionContext context)
+        {
+            _correlationContext.CorrelationId = context.InvocationId.ToString();
+        }
+    }
+}

--- a/source/GreenEnergyHub.TimeSeries/source/GreenEnergyHub.TimeSeries.MessageReceiver/host.json
+++ b/source/GreenEnergyHub.TimeSeries/source/GreenEnergyHub.TimeSeries.MessageReceiver/host.json
@@ -1,0 +1,11 @@
+{
+    "version": "2.0",
+    "logging": {
+        "applicationInsights": {
+            "samplingSettings": {
+                "isEnabled": true,
+                "excludedTypes": "Request"
+            }
+        }
+    }
+}

--- a/source/GreenEnergyHub.TimeSeries/source/GreenEnergyHub.TimeSeries.MessageReceiver/local.settings.sample.json
+++ b/source/GreenEnergyHub.TimeSeries/source/GreenEnergyHub.TimeSeries.MessageReceiver/local.settings.sample.json
@@ -1,0 +1,8 @@
+{
+   "IsEncrypted": false,
+   "Values": {
+    "AzureWebJobsStorage": "UseDevelopmentStorage=true",
+    "FUNCTIONS_WORKER_RUNTIME": "dotnet",
+    "AzureWebJobsDashboard": "UseDevelopmentStorage=true",
+    }
+}


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-timeseries) before we can accept your contribution. --->

## Description

The purpose of this PR is to add the MessageReceiver Azure Function to the domain solution.

For now, it will simply reply with HTTP OK on Post requests.

Adding the function to our pipeline will be added in a separate PR.

Besides returning HTTP OK, some simple setup of correlation IDs for later use is also added, as well as preparing the use of NodaTime and adding our HealthStatus endpoint.

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

* #37 
