### PR TITLE
Remove core tools from message receiver pipeline

### DIFF
--- a/.github/workflows/message-receiver-cd.yml
+++ b/.github/workflows/message-receiver-cd.yml
@@ -45,9 +45,6 @@ jobs:
         with:
           dotnet-version: ${{ env.DOTNET_VERSION }}
 
-      - name: Setup Azure Core Tools
-        uses: ./.github/actions/azure-core-tools-install
-
       - name: Build and test project
         uses: ./.github/actions/dotnet-build-and-test
         with:

--- a/.github/workflows/message-receiver-ci.yml
+++ b/.github/workflows/message-receiver-ci.yml
@@ -56,9 +56,6 @@ jobs:
         with:
           dotnet-version: ${{ env.DOTNET_VERSION }}
 
-      - name: Setup Azure Core Tools
-        uses: ./.github/actions/azure-core-tools-install
-
       - name: Build and test project
         uses: ./.github/actions/dotnet-build-and-test
         with:


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-timeseries) before we can accept your contribution. --->

## Description

Right now we install core tools without using it, in preparation of moving to .NET 5.0

It turns out that it is not needed to install separately as the .NET Core 3.1 runtime which is needed in the pipelines anyway will actually install it.

As a result, the separate unused steps will be removed.

## References

