### PR TITLE
Set RESOURCE_GROUP_NAME env pipeline variable

### DIFF
--- a/.github/workflows/streaming-job.yml
+++ b/.github/workflows/streaming-job.yml
@@ -210,7 +210,7 @@ jobs:
     env:
       WHEEL_STORAGE_ADDRESS: https://enrgtwheels.blob.core.windows.net/wheels/
       MAIN_PYTHON_FILE: "dbfs:/streaming/enrichment_and_validation.py"
-      RESOURCE_GROUP_NAME: ${{ matrix.environment.short }}
+      RESOURCE_GROUP_NAME: ${{ matrix.environment.long }}
 
     steps:
 

--- a/.github/workflows/streaming-job.yml
+++ b/.github/workflows/streaming-job.yml
@@ -210,6 +210,7 @@ jobs:
     env:
       WHEEL_STORAGE_ADDRESS: https://enrgtwheels.blob.core.windows.net/wheels/
       MAIN_PYTHON_FILE: "dbfs:/streaming/enrichment_and_validation.py"
+      RESOURCE_GROUP_NAME: ${{ matrix.environment.short }}
 
     steps:
 


### PR DESCRIPTION
Description

Missing RESOURCE_GROUP_NAME is set up in streaming job pipeline.

## References

This PR is an addition to #74 
