### PR TITLE
Use .net 5 in timeseries domain

### DIFF
--- a/.github/workflows/message-receiver-cd.yml
+++ b/.github/workflows/message-receiver-cd.yml
@@ -26,7 +26,7 @@ on:
 env:
   CSPROJ_FILE_PATH: 'source/GreenEnergyHub.TimeSeries/source/GreenEnergyHub.TimeSeries.MessageReceiver/GreenEnergyHub.TimeSeries.MessageReceiver.csproj'
   SOLUTION_FILE_PATH: 'source/GreenEnergyHub.TimeSeries/GreenEnergyHub.TimeSeries.sln'
-  DOTNET_VERSION: '5.0'
+  DOTNET_VERSION: '5.0.202'
   ORGANISATION_NAME: 'endk'
   AZURE_FUNCTIONAPP_NAME: 'message-receiver'
   PROJECT_NAME: tseries
@@ -39,7 +39,12 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@master
-        
+
+      - name: Setup .NET 3.1 environment
+        uses: actions/setup-dotnet@v1
+        with:
+        dotnet-version: '3.1.x'
+       
       - name: Setup .NET ${{ env.DOTNET_VERSION }} environment
         uses: actions/setup-dotnet@v1
         with:

--- a/.github/workflows/message-receiver-cd.yml
+++ b/.github/workflows/message-receiver-cd.yml
@@ -26,7 +26,7 @@ on:
 env:
   CSPROJ_FILE_PATH: 'source/GreenEnergyHub.TimeSeries/source/GreenEnergyHub.TimeSeries.MessageReceiver/GreenEnergyHub.TimeSeries.MessageReceiver.csproj'
   SOLUTION_FILE_PATH: 'source/GreenEnergyHub.TimeSeries/GreenEnergyHub.TimeSeries.sln'
-  DOTNET_VERSION: '3.1'
+  DOTNET_VERSION: '5.0'
   ORGANISATION_NAME: 'endk'
   AZURE_FUNCTIONAPP_NAME: 'message-receiver'
   PROJECT_NAME: tseries

--- a/.github/workflows/message-receiver-ci.yml
+++ b/.github/workflows/message-receiver-ci.yml
@@ -22,7 +22,7 @@ on:
 env:
   CSPROJ_FILE_PATH: source/GreenEnergyHub.TimeSeries/source/GreenEnergyHub.TimeSeries.MessageReceiver/GreenEnergyHub.TimeSeries.MessageReceiver.csproj
   SOLUTION_FILE_PATH: source/GreenEnergyHub.TimeSeries/GreenEnergyHub.TimeSeries.sln
-  DOTNET_VERSION: '3.1'
+  DOTNET_VERSION: '5.0'
 
 jobs:
   pre_job:

--- a/.github/workflows/message-receiver-ci.yml
+++ b/.github/workflows/message-receiver-ci.yml
@@ -22,7 +22,7 @@ on:
 env:
   CSPROJ_FILE_PATH: source/GreenEnergyHub.TimeSeries/source/GreenEnergyHub.TimeSeries.MessageReceiver/GreenEnergyHub.TimeSeries.MessageReceiver.csproj
   SOLUTION_FILE_PATH: source/GreenEnergyHub.TimeSeries/GreenEnergyHub.TimeSeries.sln
-  DOTNET_VERSION: '5.0'
+  DOTNET_VERSION: '5.0.202'
 
 jobs:
   pre_job:
@@ -50,6 +50,11 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@master
+
+      - name: Setup .NET 3.1 environment
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: '3.1.x'
 
       - name: Setup .NET ${{ env.DOTNET_VERSION }} environment
         uses: actions/setup-dotnet@v1

--- a/build/infrastructure/azfun-timeseries-message-receiver.tf
+++ b/build/infrastructure/azfun-timeseries-message-receiver.tf
@@ -26,7 +26,7 @@ module "azfun_message_receiver" {
     WEBSITE_ENABLE_SYNC_UPDATE_SITE              = true
     WEBSITE_RUN_FROM_PACKAGE                     = 1
     WEBSITES_ENABLE_APP_SERVICE_STORAGE          = true
-    FUNCTIONS_WORKER_RUNTIME                     = "dotnet"
+    FUNCTIONS_WORKER_RUNTIME                     = "dotnet-isolated"
   }
   dependencies                              = [
     module.appi.dependent_on,

--- a/source/GreenEnergyHub.TimeSeries/GreenEnergyHub.TimeSeries.sln
+++ b/source/GreenEnergyHub.TimeSeries/GreenEnergyHub.TimeSeries.sln
@@ -40,11 +40,11 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "GreenEnergyHub.Json", "..\S
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "GreenEnergyHub.TestHelpers", "..\Shared\GreenEnergyHub\source\GreenEnergyHub.TestHelpers\GreenEnergyHub.TestHelpers.csproj", "{0C63BAFE-D498-4B77-9EFE-CA885FD7587C}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "GreenEnergyHub.TimeSeries.MessageReceiver", "source\GreenEnergyHub.TimeSeries.MessageReceiver\GreenEnergyHub.TimeSeries.MessageReceiver.csproj", "{5B29036A-F1C7-43FE-B8AA-C1A334B9E5CF}"
-EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "GreenEnergyHub.Messaging", "..\messaging\source\GreenEnergyHub.Messaging\GreenEnergyHub.Messaging.csproj", "{FD55D534-BEA4-4E95-A5C6-D2CD92EEB66A}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "GreenEnergyHub.Messaging.Integration.ServiceCollection", "..\messaging\source\GreenEnergyHub.Messaging.Integration.ServiceCollection\GreenEnergyHub.Messaging.Integration.ServiceCollection.csproj", "{E3B9BE32-B0C6-4210-AA59-769CB5A71278}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GreenEnergyHub.TimeSeries.MessageReceiver", "source\GreenEnergyHub.TimeSeries.MessageReceiver\GreenEnergyHub.TimeSeries.MessageReceiver.csproj", "{C9A35AB2-C4EF-48CF-9BA4-920020777123}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -88,10 +88,6 @@ Global
 		{0C63BAFE-D498-4B77-9EFE-CA885FD7587C}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{0C63BAFE-D498-4B77-9EFE-CA885FD7587C}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{0C63BAFE-D498-4B77-9EFE-CA885FD7587C}.Release|Any CPU.Build.0 = Release|Any CPU
-		{5B29036A-F1C7-43FE-B8AA-C1A334B9E5CF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{5B29036A-F1C7-43FE-B8AA-C1A334B9E5CF}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{5B29036A-F1C7-43FE-B8AA-C1A334B9E5CF}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{5B29036A-F1C7-43FE-B8AA-C1A334B9E5CF}.Release|Any CPU.Build.0 = Release|Any CPU
 		{FD55D534-BEA4-4E95-A5C6-D2CD92EEB66A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{FD55D534-BEA4-4E95-A5C6-D2CD92EEB66A}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{FD55D534-BEA4-4E95-A5C6-D2CD92EEB66A}.Release|Any CPU.ActiveCfg = Release|Any CPU
@@ -100,6 +96,10 @@ Global
 		{E3B9BE32-B0C6-4210-AA59-769CB5A71278}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{E3B9BE32-B0C6-4210-AA59-769CB5A71278}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{E3B9BE32-B0C6-4210-AA59-769CB5A71278}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C9A35AB2-C4EF-48CF-9BA4-920020777123}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C9A35AB2-C4EF-48CF-9BA4-920020777123}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C9A35AB2-C4EF-48CF-9BA4-920020777123}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C9A35AB2-C4EF-48CF-9BA4-920020777123}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -110,9 +110,9 @@ Global
 		{C13CD7B9-F3E4-4042-B78D-763A113EEE0D} = {8E1E68E2-7F6B-4FA3-8B97-80CA59BDB57C}
 		{BEE26AFC-4E8A-4005-B84C-487D4487423F} = {8E1E68E2-7F6B-4FA3-8B97-80CA59BDB57C}
 		{0C63BAFE-D498-4B77-9EFE-CA885FD7587C} = {8E1E68E2-7F6B-4FA3-8B97-80CA59BDB57C}
-		{5B29036A-F1C7-43FE-B8AA-C1A334B9E5CF} = {0F6D6178-E28A-445D-99A8-7CABDC3EC55A}
 		{FD55D534-BEA4-4E95-A5C6-D2CD92EEB66A} = {8E1E68E2-7F6B-4FA3-8B97-80CA59BDB57C}
 		{E3B9BE32-B0C6-4210-AA59-769CB5A71278} = {8E1E68E2-7F6B-4FA3-8B97-80CA59BDB57C}
+		{C9A35AB2-C4EF-48CF-9BA4-920020777123} = {0F6D6178-E28A-445D-99A8-7CABDC3EC55A}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {8CC9992B-81F9-4F47-8F02-D9D126AC403B}

--- a/source/GreenEnergyHub.TimeSeries/deploy-functions.cmd
+++ b/source/GreenEnergyHub.TimeSeries/deploy-functions.cmd
@@ -23,7 +23,7 @@ IF /I not "%doBuild%" == "n" (
 rem All (but the last) deployments are opened in separate windows in order to execute in parallel
 
 IF /I not "%deployMessageReceiver%" == "n" (
-    pushd source\GreenEnergyHub.TimeSeries.MessageReceiver\bin\Release\netcoreapp3.1
+    pushd source\GreenEnergyHub.TimeSeries.MessageReceiver\bin\Release\net5.0
     start "Deploy: Message Receiver" cmd /c "func azure functionapp publish azfun-message-receiver-tseries-%organization%-s & pause"
     popd
 )

--- a/source/GreenEnergyHub.TimeSeries/source/GreenEnergyHub.TimeSeries.Application/GreenEnergyHub.TimeSeries.Application.csproj
+++ b/source/GreenEnergyHub.TimeSeries/source/GreenEnergyHub.TimeSeries.Application/GreenEnergyHub.TimeSeries.Application.csproj
@@ -16,7 +16,7 @@ limitations under the License.
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <RunAnalyzersDuringBuild>true</RunAnalyzersDuringBuild>

--- a/source/GreenEnergyHub.TimeSeries/source/GreenEnergyHub.TimeSeries.Core/GreenEnergyHub.TimeSeries.Core.csproj
+++ b/source/GreenEnergyHub.TimeSeries/source/GreenEnergyHub.TimeSeries.Core/GreenEnergyHub.TimeSeries.Core.csproj
@@ -17,7 +17,7 @@ limitations under the License.
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFramework>net5.0</TargetFramework>
     </PropertyGroup>
 
     <ItemGroup>

--- a/source/GreenEnergyHub.TimeSeries/source/GreenEnergyHub.TimeSeries.Domain/GreenEnergyHub.TimeSeries.Domain.csproj
+++ b/source/GreenEnergyHub.TimeSeries/source/GreenEnergyHub.TimeSeries.Domain/GreenEnergyHub.TimeSeries.Domain.csproj
@@ -16,7 +16,7 @@ limitations under the License.
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFramework>net5.0</TargetFramework>
         <Nullable>enable</Nullable>
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
         <RunAnalyzersDuringBuild>true</RunAnalyzersDuringBuild>

--- a/source/GreenEnergyHub.TimeSeries/source/GreenEnergyHub.TimeSeries.Infrastructure/GreenEnergyHub.TimeSeries.Infrastructure.csproj
+++ b/source/GreenEnergyHub.TimeSeries/source/GreenEnergyHub.TimeSeries.Infrastructure/GreenEnergyHub.TimeSeries.Infrastructure.csproj
@@ -16,7 +16,7 @@ limitations under the License.
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFramework>net5.0</TargetFramework>
         <Nullable>enable</Nullable>
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
         <RunAnalyzersDuringBuild>true</RunAnalyzersDuringBuild>

--- a/source/GreenEnergyHub.TimeSeries/source/GreenEnergyHub.TimeSeries.MessageReceiver/GreenEnergyHub.TimeSeries.MessageReceiver.csproj
+++ b/source/GreenEnergyHub.TimeSeries/source/GreenEnergyHub.TimeSeries.MessageReceiver/GreenEnergyHub.TimeSeries.MessageReceiver.csproj
@@ -16,13 +16,16 @@ limitations under the License.
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
+    <LangVersion>9</LangVersion>
     <AzureFunctionsVersion>v3</AzureFunctionsVersion>
+    <OutputType>Exe</OutputType>
+    <_FunctionsSkipCleanOutput>true</_FunctionsSkipCleanOutput>
+    <RootNamespace>GreenEnergyHub.TimeSeries.MessageReceiver</RootNamespace>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Functions.Extensions" Version="1.1.0" />
-    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.EventHubs" Version="4.2.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="5.0.0" />
-    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="3.0.12" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.0.12" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="1.0.1" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="1.0.0" />
   </ItemGroup>
   <ItemGroup>
     <None Update="host.json">
@@ -38,8 +41,6 @@ limitations under the License.
     </None>
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\GreenEnergyHub.TimeSeries.Application\GreenEnergyHub.TimeSeries.Application.csproj" />
-    <ProjectReference Include="..\GreenEnergyHub.TimeSeries.Domain\GreenEnergyHub.TimeSeries.Domain.csproj" />
     <ProjectReference Include="..\GreenEnergyHub.TimeSeries.Infrastructure\GreenEnergyHub.TimeSeries.Infrastructure.csproj" />
   </ItemGroup>
 </Project>

--- a/source/GreenEnergyHub.TimeSeries/source/GreenEnergyHub.TimeSeries.MessageReceiver/GreenEnergyHub.TimeSeries.MessageReceiver.csproj
+++ b/source/GreenEnergyHub.TimeSeries/source/GreenEnergyHub.TimeSeries.MessageReceiver/GreenEnergyHub.TimeSeries.MessageReceiver.csproj
@@ -16,7 +16,6 @@ limitations under the License.
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
-    <LangVersion>9</LangVersion>
     <AzureFunctionsVersion>v3</AzureFunctionsVersion>
     <OutputType>Exe</OutputType>
     <_FunctionsSkipCleanOutput>true</_FunctionsSkipCleanOutput>

--- a/source/GreenEnergyHub.TimeSeries/source/GreenEnergyHub.TimeSeries.MessageReceiver/GreenEnergyHub.TimeSeries.MessageReceiver.csproj
+++ b/source/GreenEnergyHub.TimeSeries/source/GreenEnergyHub.TimeSeries.MessageReceiver/GreenEnergyHub.TimeSeries.MessageReceiver.csproj
@@ -15,13 +15,13 @@ limitations under the License.
 -->
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <AzureFunctionsVersion>v3</AzureFunctionsVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.Functions.Extensions" Version="1.1.0" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.EventHubs" Version="4.2.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.1.14" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="5.0.0" />
     <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="3.0.12" />
   </ItemGroup>
   <ItemGroup>

--- a/source/GreenEnergyHub.TimeSeries/source/GreenEnergyHub.TimeSeries.MessageReceiver/HealthStatus.cs
+++ b/source/GreenEnergyHub.TimeSeries/source/GreenEnergyHub.TimeSeries.MessageReceiver/HealthStatus.cs
@@ -15,8 +15,7 @@
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.Azure.WebJobs;
-using Microsoft.Azure.WebJobs.Extensions.Http;
+using Microsoft.Azure.Functions.Worker;
 using Microsoft.Extensions.Logging;
 
 namespace GreenEnergyHub.TimeSeries.MessageReceiver
@@ -26,7 +25,7 @@ namespace GreenEnergyHub.TimeSeries.MessageReceiver
         /// <summary>
         /// HTTP GET endpoint that can be used to monitor the health of the function app.
         /// </summary>
-        [FunctionName(nameof(HealthStatus))]
+        [Function(nameof(HealthStatus))]
         public static Task<IActionResult> RunAsync(
             [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = null)] HttpRequest req,
             ILogger log)

--- a/source/GreenEnergyHub.TimeSeries/source/GreenEnergyHub.TimeSeries.MessageReceiver/Program.cs
+++ b/source/GreenEnergyHub.TimeSeries/source/GreenEnergyHub.TimeSeries.MessageReceiver/Program.cs
@@ -12,33 +12,31 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using System.Diagnostics.CodeAnalysis;
 using GreenEnergyHub.TimeSeries.Domain.Notification;
-using GreenEnergyHub.TimeSeries.Infrastructure.Messaging;
 using GreenEnergyHub.TimeSeries.Infrastructure.Messaging.Registration;
-using GreenEnergyHub.TimeSeries.MessageReceiver;
-using Microsoft.Azure.Functions.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 using NodaTime;
-
-[assembly: FunctionsStartup(typeof(Startup))]
 
 namespace GreenEnergyHub.TimeSeries.MessageReceiver
 {
-    public class Startup : FunctionsStartup
+    public static class Program
     {
-        public override void Configure([NotNull] IFunctionsHostBuilder builder)
+        public static void Main()
         {
-            builder.Services.AddScoped(typeof(IClock), _ => SystemClock.Instance);
+            var host = new HostBuilder()
+                .ConfigureFunctionsWorkerDefaults()
+                .ConfigureServices(ConfigureServices)
+                .Build();
 
-            ConfigureMessaging(builder);
+            host.Run();
         }
 
-        private static void ConfigureMessaging(IFunctionsHostBuilder builder)
+        private static void ConfigureServices(HostBuilderContext hostBuilderContext, IServiceCollection serviceCollection)
         {
-            builder.Services
-                .AddMessaging()
-                .AddMessageExtractor<TimeSeriesCommand>();
+            serviceCollection.AddScoped(typeof(IClock), _ => SystemClock.Instance);
+            serviceCollection.AddLogging();
+            serviceCollection.AddMessaging().AddMessageExtractor<TimeSeriesCommand>();
         }
     }
 }

--- a/source/GreenEnergyHub.TimeSeries/source/GreenEnergyHub.TimeSeries.MessageReceiver/local.settings.sample.json
+++ b/source/GreenEnergyHub.TimeSeries/source/GreenEnergyHub.TimeSeries.MessageReceiver/local.settings.sample.json
@@ -1,8 +1,8 @@
 {
-   "IsEncrypted": false,
-   "Values": {
-     "AzureWebJobsStorage": "UseDevelopmentStorage=true",
-     "FUNCTIONS_WORKER_RUNTIME": "dotnet-isolated",
-     "AzureWebJobsDashboard": "UseDevelopmentStorage=true"  
+    "IsEncrypted": false,
+    "Values": {
+        "AzureWebJobsStorage": "UseDevelopmentStorage=true",
+        "FUNCTIONS_WORKER_RUNTIME": "dotnet-isolated",
+        "AzureWebJobsDashboard": "UseDevelopmentStorage=true"
     }
 }

--- a/source/GreenEnergyHub.TimeSeries/source/GreenEnergyHub.TimeSeries.MessageReceiver/local.settings.sample.json
+++ b/source/GreenEnergyHub.TimeSeries/source/GreenEnergyHub.TimeSeries.MessageReceiver/local.settings.sample.json
@@ -1,8 +1,8 @@
 {
    "IsEncrypted": false,
    "Values": {
-    "AzureWebJobsStorage": "UseDevelopmentStorage=true",
-    "FUNCTIONS_WORKER_RUNTIME": "dotnet",
-    "AzureWebJobsDashboard": "UseDevelopmentStorage=true",
+     "AzureWebJobsStorage": "UseDevelopmentStorage=true",
+     "FUNCTIONS_WORKER_RUNTIME": "dotnet-isolated",
+     "AzureWebJobsDashboard": "UseDevelopmentStorage=true"  
     }
 }

--- a/source/GreenEnergyHub.TimeSeries/source/GreenEnergyHub.TimeSeries.TestCore/GreenEnergyHub.TimeSeries.TestCore.csproj
+++ b/source/GreenEnergyHub.TimeSeries/source/GreenEnergyHub.TimeSeries.TestCore/GreenEnergyHub.TimeSeries.TestCore.csproj
@@ -16,7 +16,7 @@ limitations under the License.
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFramework>net5.0</TargetFramework>
         <Nullable>enable</Nullable>
         <IsPackable>false</IsPackable>
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
@@ -29,7 +29,7 @@ limitations under the License.
       <PackageReference Include="AutoFixture" Version="4.17.0" />
       <PackageReference Include="AutoFixture.AutoMoq" Version="4.17.0" />
       <PackageReference Include="AutoFixture.Xunit2" Version="4.17.0" />
-      <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.1.14" />
+      <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="5.0.0" />
       <PackageReference Include="System.ComponentModel.TypeConverter" Version="4.3.0" />
       <PackageReference Include="xunit.extensibility.core" Version="2.4.1" />
     </ItemGroup>

--- a/source/GreenEnergyHub.TimeSeries/source/GreenEnergyHub.TimeSeries.Tests/GreenEnergyHub.TimeSeries.Tests.csproj
+++ b/source/GreenEnergyHub.TimeSeries/source/GreenEnergyHub.TimeSeries.Tests/GreenEnergyHub.TimeSeries.Tests.csproj
@@ -16,7 +16,7 @@ limitations under the License.
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFramework>net5.0</TargetFramework>
         <Nullable>enable</Nullable>
         <IsPackable>false</IsPackable>
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/source/Shared/GreenEnergyHub/source/GreenEnergyHub.Json.Tests/GreenEnergyHub.Json.Tests.csproj
+++ b/source/Shared/GreenEnergyHub/source/GreenEnergyHub.Json.Tests/GreenEnergyHub.Json.Tests.csproj
@@ -16,7 +16,7 @@ limitations under the License.
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFramework>net5.0</TargetFramework>
     </PropertyGroup>
 
 </Project>

--- a/source/Shared/GreenEnergyHub/source/GreenEnergyHub.Json/GreenEnergyHub.Json.csproj
+++ b/source/Shared/GreenEnergyHub/source/GreenEnergyHub.Json/GreenEnergyHub.Json.csproj
@@ -17,7 +17,7 @@ limitations under the License.
 
     <PropertyGroup>
         <LangVersion>9</LangVersion>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFramework>net5.0</TargetFramework>
     </PropertyGroup>
 
     <ItemGroup>

--- a/source/Shared/GreenEnergyHub/source/GreenEnergyHub.TestHelpers.Tests/GreenEnergyHub.TestHelpers.Tests.csproj
+++ b/source/Shared/GreenEnergyHub/source/GreenEnergyHub.TestHelpers.Tests/GreenEnergyHub.TestHelpers.Tests.csproj
@@ -16,7 +16,7 @@ limitations under the License.
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFramework>net5.0</TargetFramework>
         <Nullable>enable</Nullable>
     </PropertyGroup>
 

--- a/source/Shared/GreenEnergyHub/source/GreenEnergyHub.TestHelpers/GreenEnergyHub.TestHelpers.csproj
+++ b/source/Shared/GreenEnergyHub/source/GreenEnergyHub.TestHelpers/GreenEnergyHub.TestHelpers.csproj
@@ -17,7 +17,7 @@ limitations under the License.
 
   <PropertyGroup>
     <LangVersion>9</LangVersion>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/source/iso8601/GreenEnergyHub.Iso8601.Tests/GreenEnergyHub.Iso8601.Tests.csproj
+++ b/source/iso8601/GreenEnergyHub.Iso8601.Tests/GreenEnergyHub.Iso8601.Tests.csproj
@@ -16,7 +16,7 @@ limitations under the License.
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/source/iso8601/GreenEnergyHub.Iso8601/GreenEnergyHub.Iso8601.csproj
+++ b/source/iso8601/GreenEnergyHub.Iso8601/GreenEnergyHub.Iso8601.csproj
@@ -16,7 +16,7 @@ limitations under the License.
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/source/messaging/source/GreenEnergyHub.Messaging.Integration.ServiceCollection/GreenEnergyHub.Messaging.Integration.ServiceCollection.csproj
+++ b/source/messaging/source/GreenEnergyHub.Messaging.Integration.ServiceCollection/GreenEnergyHub.Messaging.Integration.ServiceCollection.csproj
@@ -16,7 +16,7 @@ limitations under the License.
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-      <TargetFramework>netcoreapp3.1</TargetFramework>
+      <TargetFramework>net5.0</TargetFramework>
       <Nullable>enable</Nullable>
       <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
       <RunAnalyzersDuringBuild>true</RunAnalyzersDuringBuild>
@@ -27,8 +27,8 @@ limitations under the License.
 
   <ItemGroup>
       <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.2.0" />
-      <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.15" />
-      <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.1.10" />
+      <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="5.0.1" />
+      <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="5.0.0" />
       <PackageReference Include="mediatr" Version="9.0.0" />
       <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="9.0.0" />
   </ItemGroup>

--- a/source/messaging/source/GreenEnergyHub.Messaging/GreenEnergyHub.Messaging.csproj
+++ b/source/messaging/source/GreenEnergyHub.Messaging/GreenEnergyHub.Messaging.csproj
@@ -22,7 +22,7 @@ limitations under the License.
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
         <RootNamespace>GreenEnergyHub.Messaging</RootNamespace>
         <LangVersion>9</LangVersion>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFramework>net5.0</TargetFramework>
     </PropertyGroup>
 
     <ItemGroup>

--- a/source/queues/source/GreenEnergyHub.Queues.AzureServiceBus.Integration.ServiceCollection/GreenEnergyHub.Queues.AzureServiceBus.Integration.ServiceCollection.csproj
+++ b/source/queues/source/GreenEnergyHub.Queues.AzureServiceBus.Integration.ServiceCollection/GreenEnergyHub.Queues.AzureServiceBus.Integration.ServiceCollection.csproj
@@ -16,7 +16,7 @@ limitations under the License.
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFramework>net5.0</TargetFramework>
     </PropertyGroup>
 
     <ItemGroup>

--- a/source/queues/source/GreenEnergyHub.Queues.AzureServiceBus/GreenEnergyHub.Queues.AzureServiceBus.csproj
+++ b/source/queues/source/GreenEnergyHub.Queues.AzureServiceBus/GreenEnergyHub.Queues.AzureServiceBus.csproj
@@ -17,7 +17,7 @@ limitations under the License.
 
     <PropertyGroup>
         <LangVersion>9</LangVersion>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFramework>net5.0</TargetFramework>
     </PropertyGroup>
 
     <ItemGroup>

--- a/source/queues/source/GreenEnergyHub.Queues.Kafka.Integration.ServiceCollection/GreenEnergyHub.Queues.Kafka.Integration.ServiceCollection.csproj
+++ b/source/queues/source/GreenEnergyHub.Queues.Kafka.Integration.ServiceCollection/GreenEnergyHub.Queues.Kafka.Integration.ServiceCollection.csproj
@@ -16,7 +16,7 @@ limitations under the License.
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFramework>net5.0</TargetFramework>
     </PropertyGroup>
 
     <ItemGroup>

--- a/source/queues/source/GreenEnergyHub.Queues.Kafka/GreenEnergyHub.Queues.Kafka.csproj
+++ b/source/queues/source/GreenEnergyHub.Queues.Kafka/GreenEnergyHub.Queues.Kafka.csproj
@@ -16,7 +16,7 @@ limitations under the License.
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFramework>net5.0</TargetFramework>
     </PropertyGroup>
 
     <ItemGroup>

--- a/source/queues/source/GreenEnergyHub.Queues.Tests/GreenEnergyHub.Queues.Tests.csproj
+++ b/source/queues/source/GreenEnergyHub.Queues.Tests/GreenEnergyHub.Queues.Tests.csproj
@@ -16,7 +16,7 @@ limitations under the License.
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFramework>net5.0</TargetFramework>
 
         <IsPackable>false</IsPackable>
     </PropertyGroup>

--- a/source/queues/source/GreenEnergyHub.Queues.ValidationReportDispatcher/GreenEnergyHub.Queues.ValidationReportDispatcher.csproj
+++ b/source/queues/source/GreenEnergyHub.Queues.ValidationReportDispatcher/GreenEnergyHub.Queues.ValidationReportDispatcher.csproj
@@ -16,7 +16,7 @@ limitations under the License.
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/source/queues/source/GreenEnergyHub.Queues/GreenEnergyHub.Queues.csproj
+++ b/source/queues/source/GreenEnergyHub.Queues/GreenEnergyHub.Queues.csproj
@@ -17,7 +17,7 @@ limitations under the License.
 
     <PropertyGroup>
         <LangVersion>9</LangVersion>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFramework>net5.0</TargetFramework>
     </PropertyGroup>
 
     <ItemGroup>


### PR DESCRIPTION
## Description

This PR upgrades .net code in the Timeseries domain to .NET 5

MessageReceiver Startup class is replaced with Program class for a .NET 5 like implementation.
Our pipeline is updated to use .NET 5 isolated mode.
All temporary shared code is upgraded to .NET 5
