### PR TITLE
Temporary disable of the PR Envoriment Setup

### DIFF
--- a/.github/workflows/pr-env-setup.yml
+++ b/.github/workflows/pr-env-setup.yml
@@ -23,9 +23,9 @@
 name: PR Environment - Setup
 
 on:
-  pull_request:
-    branches:
-    - TEMPDISABLED
+ # pull_request:
+ #   branches:
+ #   - main
   workflow_dispatch: {}
 
 env:

--- a/.github/workflows/pr-env-setup.yml
+++ b/.github/workflows/pr-env-setup.yml
@@ -25,7 +25,6 @@ name: PR Environment - Setup
 on:
   pull_request:
     branches:
-      - main
   workflow_dispatch: {}
 
 env:
@@ -197,8 +196,8 @@ jobs:
     if: ${{ needs.streaming_pre_job.outputs.should_skip != 'true' }}
     runs-on: ubuntu-latest
     env:
-      WHEEL_STORAGE_NAME: 'enrgtwheels'
-      WHEEL_STORAGE_ADDRESS: https://enrgtwheels.blob.core.windows.net/wheels/
+      WHEEL_STORAGE_NAME: 'time${{ github.event.number }}uwheels'
+      WHEEL_STORAGE_ADDRESS: https://times${{ github.event.number }}uwheels.blob.core.windows.net/wheels/
       WHEEL_CONTAINER_NAME: 'wheels'
     environment:
       name: rg-DataHub-Testing-U

--- a/.github/workflows/pr-env-setup.yml
+++ b/.github/workflows/pr-env-setup.yml
@@ -25,6 +25,7 @@ name: PR Environment - Setup
 on:
   pull_request:
     branches:
+    - TEMPDISABLED
   workflow_dispatch: {}
 
 env:

--- a/.github/workflows/pr-env-setup.yml
+++ b/.github/workflows/pr-env-setup.yml
@@ -196,8 +196,8 @@ jobs:
     if: ${{ needs.streaming_pre_job.outputs.should_skip != 'true' }}
     runs-on: ubuntu-latest
     env:
-      WHEEL_STORAGE_NAME: 'time${{ github.event.number }}uwheels'
-      WHEEL_STORAGE_ADDRESS: https://times${{ github.event.number }}uwheels.blob.core.windows.net/wheels/
+      WHEEL_STORAGE_NAME: 'enrgtwheels'
+      WHEEL_STORAGE_ADDRESS: https://enrgtwheels.blob.core.windows.net/wheels/
       WHEEL_CONTAINER_NAME: 'wheels'
     environment:
       name: rg-DataHub-Testing-U


### PR DESCRIPTION
At the moment we have an open support ticket at CCOE regarding the issue of not being able to support the amounts of service plans needed in the rg-DataHub-Testing-U.

This PR will temporarily disables that workflow until the matter is resolved.