### PR TITLE
Update MessageReceiver Terraform with configuration needed to place TimeSeriesCommand on EventHub

### DIFF
--- a/build/infrastructure/azfun-timeseries-message-receiver.tf
+++ b/build/infrastructure/azfun-timeseries-message-receiver.tf
@@ -28,6 +28,7 @@ module "azfun_message_receiver" {
     WEBSITES_ENABLE_APP_SERVICE_STORAGE          = true
     FUNCTIONS_WORKER_RUNTIME                     = "dotnet"
     LOCAL_TIMEZONENAME                           = local.LOCAL_TIMEZONENAME
+	TIMESERIES_QUEUE_TOPIC                       = module.evh_receivedqueue.name
     TIMESERIES_QUEUE_URL                         = "${module.evhnm_received_queue.name}.servicebus.windows.net:9093"
     TIMESERIES_QUEUE_CONNECTION_STRING           = module.evhar_receivedqueue_sender.primary_connection_string
   }

--- a/build/infrastructure/azfun-timeseries-message-receiver.tf
+++ b/build/infrastructure/azfun-timeseries-message-receiver.tf
@@ -27,6 +27,9 @@ module "azfun_message_receiver" {
     WEBSITE_RUN_FROM_PACKAGE                     = 1
     WEBSITES_ENABLE_APP_SERVICE_STORAGE          = true
     FUNCTIONS_WORKER_RUNTIME                     = "dotnet"
+    LOCAL_TIMEZONENAME                           = local.LOCAL_TIMEZONENAME
+    TIMESERIES_QUEUE_URL                         = "${module.evhnm_received_queue.name}.servicebus.windows.net:9093"
+    TIMESERIES_QUEUE_CONNECTION_STRING           = module.evhar_receivedqueue_sender.primary_connection_string
   }
   dependencies                              = [
     module.appi.dependent_on,

--- a/build/infrastructure/azfun-timeseries-message-receiver.tf
+++ b/build/infrastructure/azfun-timeseries-message-receiver.tf
@@ -28,7 +28,7 @@ module "azfun_message_receiver" {
     WEBSITES_ENABLE_APP_SERVICE_STORAGE          = true
     FUNCTIONS_WORKER_RUNTIME                     = "dotnet-isolated"
     LOCAL_TIMEZONENAME                           = local.LOCAL_TIMEZONENAME
-	TIMESERIES_QUEUE_TOPIC                       = module.evh_receivedqueue.name
+    TIMESERIES_QUEUE_TOPIC                       = module.evh_receivedqueue.name
     TIMESERIES_QUEUE_URL                         = "${module.evhnm_received_queue.name}.servicebus.windows.net:9093"
     TIMESERIES_QUEUE_CONNECTION_STRING           = module.evhar_receivedqueue_sender.primary_connection_string
   }

--- a/build/infrastructure/locals.tf
+++ b/build/infrastructure/locals.tf
@@ -12,4 +12,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 locals {
+    LOCAL_TIMEZONENAME = "Europe/Copenhagen"
 }


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-timeseries) before we can accept your contribution. --->

## Description

The purpose of this PR is to add the needed configuration to the MessageReceiver Azure Function to be able to place TimeSeriesCommands on the EventHub.

The actual code updating the MessageReceiver will come in a later PR, this just prepares the needed variables in Terraform deployment.

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

* #72 
