### PR TITLE
Change authorization level back to anon on message receiver

### DIFF
--- a/source/GreenEnergyHub.TimeSeries/source/GreenEnergyHub.TimeSeries.MessageReceiver/TimeSeriesHttpTrigger.cs
+++ b/source/GreenEnergyHub.TimeSeries/source/GreenEnergyHub.TimeSeries.MessageReceiver/TimeSeriesHttpTrigger.cs
@@ -47,7 +47,7 @@ namespace GreenEnergyHub.TimeSeries.MessageReceiver
 
         [Function(FunctionName)]
         public async Task<IActionResult> RunAsync(
-            [HttpTrigger(AuthorizationLevel.Function, "get", "post")]
+            [HttpTrigger(AuthorizationLevel.Anonymous, "get", "post")]
             [NotNull] HttpRequestData req,
             [NotNull] FunctionContext context)
         {


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-timeseries) before we can accept your contribution. --->

## Description

The purpose of this PR is to allow us to call the triggers again using anon.

A previous PR had changed this by mistake.

## References

* #77 
