### PR TITLE
Fix streaming job pipeline

### DIFF
--- a/.github/workflows/streaming-job.yml
+++ b/.github/workflows/streaming-job.yml
@@ -212,7 +212,7 @@ jobs:
       WHEEL_STORAGE_ADDRESS: https://tseries${{ matrix.environment.short }}.blob.core.windows.net/wheels/
       MAIN_PYTHON_FILE: "dbfs:/streaming/enrichment_and_validation.py"
       RESOURCE_GROUP_NAME: ${{ matrix.environment.long }}
-
+      ENVIRONMENT_SHORT: ${{ matrix.environment.short }}
     steps:
 
       - name: Checkout code


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-timeseries) before we can accept your contribution. --->

## Description

The purpose of this PR is to fix the broken streaming job pipeline.

* Add short environment name to environment in stream job

## References


