### PR TITLE
Rename Document namespace from Common to MarketDocument

### DIFF
--- a/source/GreenEnergyHub.TimeSeries/source/GreenEnergyHub.TimeSeries.Domain/GreenEnergyHub.TimeSeries.Domain.csproj
+++ b/source/GreenEnergyHub.TimeSeries/source/GreenEnergyHub.TimeSeries.Domain/GreenEnergyHub.TimeSeries.Domain.csproj
@@ -30,7 +30,7 @@ limitations under the License.
     </ItemGroup>
 
     <ItemGroup>
-      <Folder Include="Common" />
+      <Folder Include="MarketDocument" />
       <Folder Include="Messages" />
     </ItemGroup>
 

--- a/source/GreenEnergyHub.TimeSeries/source/GreenEnergyHub.TimeSeries.Domain/MarketDocument/BusinessReasonCode.cs
+++ b/source/GreenEnergyHub.TimeSeries/source/GreenEnergyHub.TimeSeries.Domain/MarketDocument/BusinessReasonCode.cs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-namespace GreenEnergyHub.TimeSeries.Domain.Common
+namespace GreenEnergyHub.TimeSeries.Domain.MarketDocument
 {
     /// <summary>
     /// BusinessReasonCode indicates the intended business context.

--- a/source/GreenEnergyHub.TimeSeries/source/GreenEnergyHub.TimeSeries.Domain/MarketDocument/Document.cs
+++ b/source/GreenEnergyHub.TimeSeries/source/GreenEnergyHub.TimeSeries.Domain/MarketDocument/Document.cs
@@ -12,26 +12,37 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using NodaTime;
+
 #pragma warning disable 8618
-namespace GreenEnergyHub.TimeSeries.Domain.Common
+
+namespace GreenEnergyHub.TimeSeries.Domain.MarketDocument
 {
     // Non-nullable member is uninitialized is ignored
     // Only properties which is allowed to be null is nullable
-
-    /// <summary>
-    /// A market participant, e.g. a metered data responsible, whom may submit a time series.
-    /// </summary>
-    public class MarketParticipant
+    public class Document
     {
         /// <summary>
-        /// Contains an ID that identifies the Market Participants. In Denmark this would be the GLN number or EIC code.
+        /// An ID provided by the sender.
         /// </summary>
         public string Id { get; set; }
 
         /// <summary>
-        /// Contains the role a market participant uses when initiating and communicating with Green Energy Hub
-        /// about a specific business process, e.g. Metered Data Responsible use 'MDR' when sending a time series.
+        ///  Point in time set by the TimeSeries domain
         /// </summary>
-        public MarketParticipantRole BusinessProcessRole { get; set; }
+        public Instant RequestDateTime { get; set; } = SystemClock.Instance.GetCurrentInstant();
+
+        public DocumentType Type { get; set; }
+
+        /// <summary>
+        /// A point in time provided by the sender
+        /// </summary>
+        public Instant CreatedDateTime { get; set; }
+
+        public MarketParticipant Sender { get; set; }
+
+        public MarketParticipant Recipient { get; set; }
+
+        public BusinessReasonCode BusinessReasonCode { get; set; }
     }
 }

--- a/source/GreenEnergyHub.TimeSeries/source/GreenEnergyHub.TimeSeries.Domain/MarketDocument/DocumentType.cs
+++ b/source/GreenEnergyHub.TimeSeries/source/GreenEnergyHub.TimeSeries.Domain/MarketDocument/DocumentType.cs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-namespace GreenEnergyHub.TimeSeries.Domain.Common
+namespace GreenEnergyHub.TimeSeries.Domain.MarketDocument
 {
     /// <summary>
     /// The document type indicates the intended business context of this business message.

--- a/source/GreenEnergyHub.TimeSeries/source/GreenEnergyHub.TimeSeries.Domain/MarketDocument/IndustryClassification.cs
+++ b/source/GreenEnergyHub.TimeSeries/source/GreenEnergyHub.TimeSeries.Domain/MarketDocument/IndustryClassification.cs
@@ -11,20 +11,14 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
-using GreenEnergyHub.TimeSeries.Domain.Common;
-
-namespace GreenEnergyHub.TimeSeries.Infrastructure.Messaging.Serialization.Common
+namespace GreenEnergyHub.TimeSeries.Domain.MarketDocument
 {
-    public static class DocumentTypeMapper
+    /// <summary>
+    /// IndustryClassification indicates the industry context. E.g. if a time series is related to electricity.
+    /// </summary>
+    public enum IndustryClassification
     {
-        public static DocumentType Map(string value)
-        {
-            return value switch
-            {
-                "E66" => DocumentType.NotifyValidatedMeasureData,
-                _ => DocumentType.Unknown
-            };
-        }
+        Unknown = 0,
+        Electricity = 1,
     }
 }

--- a/source/GreenEnergyHub.TimeSeries/source/GreenEnergyHub.TimeSeries.Domain/MarketDocument/MarketParticipant.cs
+++ b/source/GreenEnergyHub.TimeSeries/source/GreenEnergyHub.TimeSeries.Domain/MarketDocument/MarketParticipant.cs
@@ -12,36 +12,26 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using NodaTime;
 #pragma warning disable 8618
-
-namespace GreenEnergyHub.TimeSeries.Domain.Common
+namespace GreenEnergyHub.TimeSeries.Domain.MarketDocument
 {
     // Non-nullable member is uninitialized is ignored
     // Only properties which is allowed to be null is nullable
-    public class Document
+
+    /// <summary>
+    /// A market participant, e.g. a metered data responsible, whom may submit a time series.
+    /// </summary>
+    public class MarketParticipant
     {
         /// <summary>
-        /// An ID provided by the sender.
+        /// Contains an ID that identifies the Market Participants. In Denmark this would be the GLN number or EIC code.
         /// </summary>
         public string Id { get; set; }
 
         /// <summary>
-        ///  Point in time set by the TimeSeries domain
+        /// Contains the role a market participant uses when initiating and communicating with Green Energy Hub
+        /// about a specific business process, e.g. Metered Data Responsible use 'MDR' when sending a time series.
         /// </summary>
-        public Instant RequestDateTime { get; set; } = SystemClock.Instance.GetCurrentInstant();
-
-        public DocumentType Type { get; set; }
-
-        /// <summary>
-        /// A point in time provided by the sender
-        /// </summary>
-        public Instant CreatedDateTime { get; set; }
-
-        public MarketParticipant Sender { get; set; }
-
-        public MarketParticipant Recipient { get; set; }
-
-        public BusinessReasonCode BusinessReasonCode { get; set; }
+        public MarketParticipantRole BusinessProcessRole { get; set; }
     }
 }

--- a/source/GreenEnergyHub.TimeSeries/source/GreenEnergyHub.TimeSeries.Domain/MarketDocument/MarketParticipantRole.cs
+++ b/source/GreenEnergyHub.TimeSeries/source/GreenEnergyHub.TimeSeries.Domain/MarketDocument/MarketParticipantRole.cs
@@ -11,14 +11,20 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-namespace GreenEnergyHub.TimeSeries.Domain.Common
+
+namespace GreenEnergyHub.TimeSeries.Domain.MarketDocument
 {
     /// <summary>
-    /// IndustryClassification indicates the industry context. E.g. if a time series is related to electricity.
+    /// IMPORTANT: This is used in transport so the numbers matters.
     /// </summary>
-    public enum IndustryClassification
+    public enum MarketParticipantRole
     {
         Unknown = 0,
-        Electricity = 1,
+        EnergySupplier = 1,
+        GridAccessProvider = 2,
+        SystemOperator = 3,
+        MeteredDataResponsible = 4,
+        EnergyAgency = 5,
+        MeteredDataAdministrator = 6,
     }
 }

--- a/source/GreenEnergyHub.TimeSeries/source/GreenEnergyHub.TimeSeries.Domain/Notification/TimeSeriesCommand.cs
+++ b/source/GreenEnergyHub.TimeSeries/source/GreenEnergyHub.TimeSeries.Domain/Notification/TimeSeriesCommand.cs
@@ -14,7 +14,7 @@
 
 using System.Diagnostics.CodeAnalysis;
 using GreenEnergyHub.TimeSeries.Domain.Command;
-using GreenEnergyHub.TimeSeries.Domain.Common;
+using GreenEnergyHub.TimeSeries.Domain.MarketDocument;
 
 #pragma warning disable 8618
 

--- a/source/GreenEnergyHub.TimeSeries/source/GreenEnergyHub.TimeSeries.Infrastructure/Messaging/Serialization/Commands/TimeSeriesCommandConverter.cs
+++ b/source/GreenEnergyHub.TimeSeries/source/GreenEnergyHub.TimeSeries.Infrastructure/Messaging/Serialization/Commands/TimeSeriesCommandConverter.cs
@@ -12,16 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Threading.Tasks;
 using System.Xml;
 using GreenEnergyHub.Iso8601;
 using GreenEnergyHub.Messaging.Transport;
-using GreenEnergyHub.TimeSeries.Domain.Common;
+using GreenEnergyHub.TimeSeries.Domain.MarketDocument;
 using GreenEnergyHub.TimeSeries.Domain.Notification;
-using GreenEnergyHub.TimeSeries.Infrastructure.Messaging.Serialization.Common;
+using GreenEnergyHub.TimeSeries.Infrastructure.Messaging.Serialization.MarketDocument;
 using NodaTime;
 
 namespace GreenEnergyHub.TimeSeries.Infrastructure.Messaging.Serialization.Commands

--- a/source/GreenEnergyHub.TimeSeries/source/GreenEnergyHub.TimeSeries.Infrastructure/Messaging/Serialization/Commands/TimeSeriesCommandDeserializer.cs
+++ b/source/GreenEnergyHub.TimeSeries/source/GreenEnergyHub.TimeSeries.Infrastructure/Messaging/Serialization/Commands/TimeSeriesCommandDeserializer.cs
@@ -12,15 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using System;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Xml;
 using GreenEnergyHub.Messaging.Transport;
-using GreenEnergyHub.TimeSeries.Domain.Common;
-using GreenEnergyHub.TimeSeries.Domain.Notification;
-using NodaTime;
 
 namespace GreenEnergyHub.TimeSeries.Infrastructure.Messaging.Serialization.Commands
 {

--- a/source/GreenEnergyHub.TimeSeries/source/GreenEnergyHub.TimeSeries.Infrastructure/Messaging/Serialization/MarketDocument/BusinessReasonCodeMapper.cs
+++ b/source/GreenEnergyHub.TimeSeries/source/GreenEnergyHub.TimeSeries.Infrastructure/Messaging/Serialization/MarketDocument/BusinessReasonCodeMapper.cs
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using GreenEnergyHub.TimeSeries.Domain.Common;
+using GreenEnergyHub.TimeSeries.Domain.MarketDocument;
 
-namespace GreenEnergyHub.TimeSeries.Infrastructure.Messaging.Serialization.Common
+namespace GreenEnergyHub.TimeSeries.Infrastructure.Messaging.Serialization.MarketDocument
 {
     public static class BusinessReasonCodeMapper
     {

--- a/source/GreenEnergyHub.TimeSeries/source/GreenEnergyHub.TimeSeries.Infrastructure/Messaging/Serialization/MarketDocument/CimDocumentConverterConstants.cs
+++ b/source/GreenEnergyHub.TimeSeries/source/GreenEnergyHub.TimeSeries.Infrastructure/Messaging/Serialization/MarketDocument/CimDocumentConverterConstants.cs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-namespace GreenEnergyHub.TimeSeries.Infrastructure.Messaging.Serialization.Common
+namespace GreenEnergyHub.TimeSeries.Infrastructure.Messaging.Serialization.MarketDocument
 {
     /// <summary>
     /// Strings used in CIM/XML for elements, namespaces or attributes that we need to

--- a/source/GreenEnergyHub.TimeSeries/source/GreenEnergyHub.TimeSeries.Infrastructure/Messaging/Serialization/MarketDocument/DocumentConverter.cs
+++ b/source/GreenEnergyHub.TimeSeries/source/GreenEnergyHub.TimeSeries.Infrastructure/Messaging/Serialization/MarketDocument/DocumentConverter.cs
@@ -16,10 +16,10 @@ using System.Diagnostics.CodeAnalysis;
 using System.Threading.Tasks;
 using System.Xml;
 using GreenEnergyHub.Messaging.Transport;
-using GreenEnergyHub.TimeSeries.Domain.Common;
+using GreenEnergyHub.TimeSeries.Domain.MarketDocument;
 using NodaTime;
 
-namespace GreenEnergyHub.TimeSeries.Infrastructure.Messaging.Serialization.Common
+namespace GreenEnergyHub.TimeSeries.Infrastructure.Messaging.Serialization.MarketDocument
 {
     public abstract class DocumentConverter
     {

--- a/source/GreenEnergyHub.TimeSeries/source/GreenEnergyHub.TimeSeries.Infrastructure/Messaging/Serialization/MarketDocument/DocumentTypeMapper.cs
+++ b/source/GreenEnergyHub.TimeSeries/source/GreenEnergyHub.TimeSeries.Infrastructure/Messaging/Serialization/MarketDocument/DocumentTypeMapper.cs
@@ -12,19 +12,19 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-namespace GreenEnergyHub.TimeSeries.Domain.Common
+using GreenEnergyHub.TimeSeries.Domain.MarketDocument;
+
+namespace GreenEnergyHub.TimeSeries.Infrastructure.Messaging.Serialization.MarketDocument
 {
-    /// <summary>
-    /// IMPORTANT: This is used in transport so the numbers matters.
-    /// </summary>
-    public enum MarketParticipantRole
+    public static class DocumentTypeMapper
     {
-        Unknown = 0,
-        EnergySupplier = 1,
-        GridAccessProvider = 2,
-        SystemOperator = 3,
-        MeteredDataResponsible = 4,
-        EnergyAgency = 5,
-        MeteredDataAdministrator = 6,
+        public static DocumentType Map(string value)
+        {
+            return value switch
+            {
+                "E66" => DocumentType.NotifyValidatedMeasureData,
+                _ => DocumentType.Unknown
+            };
+        }
     }
 }

--- a/source/GreenEnergyHub.TimeSeries/source/GreenEnergyHub.TimeSeries.Infrastructure/Messaging/Serialization/MarketDocument/MarketParticipantRoleMapper.cs
+++ b/source/GreenEnergyHub.TimeSeries/source/GreenEnergyHub.TimeSeries.Infrastructure/Messaging/Serialization/MarketDocument/MarketParticipantRoleMapper.cs
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using GreenEnergyHub.TimeSeries.Domain.Common;
+using GreenEnergyHub.TimeSeries.Domain.MarketDocument;
 
-namespace GreenEnergyHub.TimeSeries.Infrastructure.Messaging.Serialization.Common
+namespace GreenEnergyHub.TimeSeries.Infrastructure.Messaging.Serialization.MarketDocument
 {
     public static class MarketParticipantRoleMapper
     {

--- a/source/GreenEnergyHub.TimeSeries/source/GreenEnergyHub.TimeSeries.Tests/GreenEnergyHub.TimeSeries.Tests.csproj
+++ b/source/GreenEnergyHub.TimeSeries/source/GreenEnergyHub.TimeSeries.Tests/GreenEnergyHub.TimeSeries.Tests.csproj
@@ -56,9 +56,4 @@ limitations under the License.
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
         <PackageReference Include="coverlet.collector" Version="3.0.3" />
     </ItemGroup>
-
-    <ItemGroup>
-      <Folder Include="Infrastructure\Messaging\Serialization\Common\" />
-    </ItemGroup>
-
 </Project>

--- a/source/GreenEnergyHub.TimeSeries/source/GreenEnergyHub.TimeSeries.Tests/Infrastructure/Messaging/Serialization/Commands/TimeSeriesCommandConverterTests.cs
+++ b/source/GreenEnergyHub.TimeSeries/source/GreenEnergyHub.TimeSeries.Tests/Infrastructure/Messaging/Serialization/Commands/TimeSeriesCommandConverterTests.cs
@@ -20,7 +20,7 @@ using System.Threading.Tasks;
 using System.Xml;
 using AutoFixture.Xunit2;
 using GreenEnergyHub.Iso8601;
-using GreenEnergyHub.TimeSeries.Domain.Common;
+using GreenEnergyHub.TimeSeries.Domain.MarketDocument;
 using GreenEnergyHub.TimeSeries.Domain.Notification;
 using GreenEnergyHub.TimeSeries.Infrastructure.Messaging;
 using GreenEnergyHub.TimeSeries.Infrastructure.Messaging.Serialization.Commands;


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-timeseries) before we can accept your contribution. --->

## Description

The purpose of this PR is to rename our Document based namespaces to use MarketDocument instead of Common in the naming.

This PR contains:
* Domain Common namespace renamed to MarketDocument
* Infrastructure Common namespace named to MarketDocument
* Some housekeeping by removing some unused namespaces in affected files
* Removed empty Common folder from test project
