### PR TITLE
Fix storage account name to streaming job

### DIFF
--- a/.github/workflows/streaming-job.yml
+++ b/.github/workflows/streaming-job.yml
@@ -293,7 +293,7 @@ jobs:
           echo "TF_VAR_environment=${{ matrix.environment.short }}" >> $GITHUB_ENV
           echo "TF_VAR_organisation=${{ env.ORGANISATION_NAME }}" >> $GITHUB_ENV
           echo "TF_VAR_resource_group_name=${{ matrix.environment.long }}" >> $GITHUB_ENV
-          echo "TF_VAR_storage_account_name=data${{ env.ORGANISATION_NAME }}${{ matrix.environment.short }}" >> $GITHUB_ENV
+          echo "TF_VAR_storage_account_name=data${{ env.PROJECT_NAME }}${{ env.ORGANISATION_NAME }}${{ matrix.environment.short }}" >> $GITHUB_ENV
           echo "TF_VAR_keyvault_id=${{ steps.obtain-keyvault-id-name.outputs.keyvault-id }}" >> $GITHUB_ENV
           echo "TF_VAR_databricks_id=${{ steps.obtain-db-id-url.outputs.workspace-id }}" >> $GITHUB_ENV
           echo "TF_VAR_python_main_file=${{ env.MAIN_PYTHON_FILE}}" >> $GITHUB_ENV


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-timeseries) before we can accept your contribution. --->

## Description

The purpose of this PR is to fix the storage account name used by the streaming job which was missing the project portion

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

* #38 
