### PR TITLE
Update HealthStatus to use isolated function parameters

### DIFF
--- a/source/GreenEnergyHub.TimeSeries/source/GreenEnergyHub.TimeSeries.MessageReceiver/HealthStatus.cs
+++ b/source/GreenEnergyHub.TimeSeries/source/GreenEnergyHub.TimeSeries.MessageReceiver/HealthStatus.cs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using System.Diagnostics.CodeAnalysis;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
@@ -20,18 +21,26 @@ using Microsoft.Extensions.Logging;
 
 namespace GreenEnergyHub.TimeSeries.MessageReceiver
 {
-    public static class HealthStatus
+    public class HealthStatus
     {
+        private readonly ILogger _log;
+
+        public HealthStatus([NotNull] ILoggerFactory loggerFactory)
+        {
+            _log = loggerFactory.CreateLogger(nameof(HealthStatus));
+        }
+
         /// <summary>
         /// HTTP GET endpoint that can be used to monitor the health of the function app.
         /// </summary>
         [Function(nameof(HealthStatus))]
-        public static Task<IActionResult> RunAsync(
-            [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = null)] HttpRequest req,
-            ILogger log)
+        public Task<IActionResult> RunAsync(
+            [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = null)]
+            [NotNull] HttpRequest req,
+            [NotNull] FunctionContext context)
         {
-            log.LogInformation("Health Status API invoked");
-            log.LogDebug("Workaround for unused method argument", req);
+            _log.LogInformation("Health Status API invoked");
+            _log.LogDebug("Workaround for unused method arguments", req, context);
 
             /* Consider checking access to used Service Bus topics and other health checks */
 


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-timeseries) before we can accept your contribution. --->

## Description

The purpose of this PR is to update the HealthStatus trigger to use isolated syntax.

It was previously failing when called.

## References
