### PR TITLE
Use HttpRequestData in HealthStatus

### DIFF
--- a/source/GreenEnergyHub.TimeSeries/source/GreenEnergyHub.TimeSeries.MessageReceiver/HealthStatus.cs
+++ b/source/GreenEnergyHub.TimeSeries/source/GreenEnergyHub.TimeSeries.MessageReceiver/HealthStatus.cs
@@ -14,9 +14,9 @@
 
 using System.Diagnostics.CodeAnalysis;
 using System.Threading.Tasks;
-using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Azure.Functions.Worker;
+using Microsoft.Azure.Functions.Worker.Http;
 using Microsoft.Extensions.Logging;
 
 namespace GreenEnergyHub.TimeSeries.MessageReceiver
@@ -36,7 +36,7 @@ namespace GreenEnergyHub.TimeSeries.MessageReceiver
         [Function(nameof(HealthStatus))]
         public Task<IActionResult> RunAsync(
             [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = null)]
-            [NotNull] HttpRequest req,
+            [NotNull] HttpRequestData req,
             [NotNull] FunctionContext context)
         {
             _log.LogInformation("Health Status API invoked");


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-timeseries) before we can accept your contribution. --->

## Description

The purpose of this PR is to use HttpRequestData instead of HttpRequest to be compatible with isolated functions in .NET 5.0

## References

