### PR TITLE
Sonarcloud path update

### DIFF
--- a/.github/workflows/sonarcloud-dotnet.yml
+++ b/.github/workflows/sonarcloud-dotnet.yml
@@ -4,21 +4,14 @@ on:
     branches:
       - main
     paths:
-      - source/GreenEnergyHub.TimeSeries/**
-      - source/iso8601/**
-      - source/messaging/**
-      - source/queues/**
-      - source/Shared/**
+      - source/**
+      - '!source/streaming/**'
       - .github/workflows/sonarcloud-dotnet.yml
   pull_request:
     types: [opened, synchronize, reopened]
     paths:
       - source/**
-      - source/GreenEnergyHub.TimeSeries/**
-      - source/iso8601/**
-      - source/messaging/**
-      - source/queues/**
-      - source/Shared/**
+      - '!source/streaming/**'
       - .github/workflows/sonarcloud-dotnet.yml
 env:
   SOLUTION_PATH: 'source\GreenEnergyHub.TimeSeries\GreenEnergyHub.TimeSeries.sln'

--- a/.github/workflows/sonarcloud-dotnet.yml
+++ b/.github/workflows/sonarcloud-dotnet.yml
@@ -6,9 +6,11 @@ on:
     paths:
       - source/**
       - .github/workflows/sonarcloud-dotnet.yml
-
   pull_request:
     types: [opened, synchronize, reopened]
+    paths:
+      - source/**
+      - .github/workflows/sonarcloud-dotnet.yml
 env:
   SOLUTION_PATH: 'source\GreenEnergyHub.TimeSeries\GreenEnergyHub.TimeSeries.sln'
   DOTNET_VERSION: '5.0.x'

--- a/.github/workflows/sonarcloud-dotnet.yml
+++ b/.github/workflows/sonarcloud-dotnet.yml
@@ -4,12 +4,21 @@ on:
     branches:
       - main
     paths:
-      - source/**
+      - source/GreenEnergyHub.TimeSeries/**
+      - source/iso8601/**
+      - source/messaging/**
+      - source/queues/**
+      - source/Shared/**
       - .github/workflows/sonarcloud-dotnet.yml
   pull_request:
     types: [opened, synchronize, reopened]
     paths:
       - source/**
+      - source/GreenEnergyHub.TimeSeries/**
+      - source/iso8601/**
+      - source/messaging/**
+      - source/queues/**
+      - source/Shared/**
       - .github/workflows/sonarcloud-dotnet.yml
 env:
   SOLUTION_PATH: 'source\GreenEnergyHub.TimeSeries\GreenEnergyHub.TimeSeries.sln'

--- a/.github/workflows/sonarcloud-python.yml
+++ b/.github/workflows/sonarcloud-python.yml
@@ -8,6 +8,9 @@ on:
       - .github/workflows/sonarcloud-python.yml
   pull_request:
     types: [opened, synchronize, reopened]
+    paths:
+      - source/streaming/**
+      - .github/workflows/sonarcloud-python.yml
 jobs:
   sonarcloud:
     name: SonarCloud


### PR DESCRIPTION
This PR will update when Sonarcloud workflow will trigger. Previously the Dotnet Sonarcloud workflow would trigger on updates made to the streaming code. 