### PR TITLE
Replacing D99 value for QuantityMissing with correct value A02 and renaming QuantityQuality to Quality

### DIFF
--- a/source/GreenEnergyHub.TimeSeries/source/GreenEnergyHub.TimeSeries.Domain/Notification/Point.cs
+++ b/source/GreenEnergyHub.TimeSeries/source/GreenEnergyHub.TimeSeries.Domain/Notification/Point.cs
@@ -27,6 +27,6 @@ namespace GreenEnergyHub.TimeSeries.Domain.Notification
 
         public decimal Quantity { get; set; }
 
-        public QuantityQuality Quality { get; set; }
+        public Quality Quality { get; set; }
     }
 }

--- a/source/GreenEnergyHub.TimeSeries/source/GreenEnergyHub.TimeSeries.Domain/Notification/Quality.cs
+++ b/source/GreenEnergyHub.TimeSeries/source/GreenEnergyHub.TimeSeries.Domain/Notification/Quality.cs
@@ -14,13 +14,13 @@
 
 namespace GreenEnergyHub.TimeSeries.Domain.Notification
 {
-    public enum QuantityQuality
+    public enum Quality
     {
         Unknown = 0,
         Measured = 1, // Received as E01 in ebiX
         Revised = 2, // Received as 36 in ebiX
         Estimated = 3, // Received as 56 in ebiX
-        QuantityMissing = 4, // Received in separate boolean field in ebiX
+        QuantityMissing = 4, // Received in separate boolean field in ebiX / Received as A02 in cim
         Calculated = 5, // Received as D01 in ebiX
     }
 }

--- a/source/GreenEnergyHub.TimeSeries/source/GreenEnergyHub.TimeSeries.Domain/Notification/Quality.cs
+++ b/source/GreenEnergyHub.TimeSeries/source/GreenEnergyHub.TimeSeries.Domain/Notification/Quality.cs
@@ -17,10 +17,10 @@ namespace GreenEnergyHub.TimeSeries.Domain.Notification
     public enum Quality
     {
         Unknown = 0,
-        Measured = 1, // Received as E01 in ebiX
-        Revised = 2, // Received as 36 in ebiX
-        Estimated = 3, // Received as 56 in ebiX
-        QuantityMissing = 4, // Received in separate boolean field in ebiX / Received as A02 in cim
-        Calculated = 5, // Received as D01 in ebiX
+        Measured = 1, // Received as E01 in ebIX
+        Revised = 2, // Received as 36 in ebIX
+        Estimated = 3, // Received as 56 in ebIX
+        QuantityMissing = 4, // Received in separate boolean field in ebIX / Received as A02 in CIM
+        Calculated = 5, // Received as D01 in ebIX
     }
 }

--- a/source/GreenEnergyHub.TimeSeries/source/GreenEnergyHub.TimeSeries.Infrastructure/Messaging/Serialization/Commands/QualityMapper.cs
+++ b/source/GreenEnergyHub.TimeSeries/source/GreenEnergyHub.TimeSeries.Infrastructure/Messaging/Serialization/Commands/QualityMapper.cs
@@ -16,18 +16,18 @@ using GreenEnergyHub.TimeSeries.Domain.Notification;
 
 namespace GreenEnergyHub.TimeSeries.Infrastructure.Messaging.Serialization.Commands
 {
-    public static class QuantityQualityMapper
+    public static class QualityMapper
     {
-        public static QuantityQuality Map(string value)
+        public static Quality Map(string value)
         {
             return value switch
             {
-                "E01" => QuantityQuality.Measured,
-                "56" => QuantityQuality.Estimated,
-                "36" => QuantityQuality.Revised,
-                "D01" => QuantityQuality.Calculated,
-                "D99" => QuantityQuality.QuantityMissing, // D99 is probably not the correct quantity missing code.
-                _ => QuantityQuality.Unknown,
+                "E01" => Quality.Measured,
+                "56" => Quality.Estimated,
+                "36" => Quality.Revised,
+                "D01" => Quality.Calculated,
+                "A02" => Quality.QuantityMissing,
+                _ => Quality.Unknown,
             };
         }
     }

--- a/source/GreenEnergyHub.TimeSeries/source/GreenEnergyHub.TimeSeries.Infrastructure/Messaging/Serialization/Commands/TimeSeriesCommandConverter.cs
+++ b/source/GreenEnergyHub.TimeSeries/source/GreenEnergyHub.TimeSeries.Infrastructure/Messaging/Serialization/Commands/TimeSeriesCommandConverter.cs
@@ -152,7 +152,7 @@ namespace GreenEnergyHub.TimeSeries.Infrastructure.Messaging.Serialization.Comma
         private async Task<Point> ParsePointAsync(XmlReader reader, Series series)
         {
             // The CIM xml element 'quality' may be skipped and if so, the point's quality must default to 'Measured'
-            var point = new Point() { Quality = QuantityQuality.Measured };
+            var point = new Point() { Quality = Quality.Measured };
 
             while (await reader.ReadAsync().ConfigureAwait(false))
             {
@@ -169,7 +169,7 @@ namespace GreenEnergyHub.TimeSeries.Infrastructure.Messaging.Serialization.Comma
                 else if (reader.Is(CimTimeSeriesCommandConstants.Quality, CimTimeSeriesCommandConstants.Namespace))
                 {
                     var content = await reader.ReadElementContentAsStringAsync().ConfigureAwait(false);
-                    point.Quality = QuantityQualityMapper.Map(content);
+                    point.Quality = QualityMapper.Map(content);
                 }
                 else if (reader.Is(CimTimeSeriesCommandConstants.Point, CimTimeSeriesCommandConstants.Namespace, XmlNodeType.EndElement))
                 {

--- a/source/GreenEnergyHub.TimeSeries/source/GreenEnergyHub.TimeSeries.Tests/GreenEnergyHub.TimeSeries.Tests.csproj
+++ b/source/GreenEnergyHub.TimeSeries/source/GreenEnergyHub.TimeSeries.Tests/GreenEnergyHub.TimeSeries.Tests.csproj
@@ -28,10 +28,12 @@ limitations under the License.
     <ItemGroup>
       <None Remove="TestFiles\Valid_Hourly_CIM_TimeSeries.xml" />
       <None Remove="TestFiles\Valid_Hourly_CIM_TimeSeries_withoutQualityElements.xml" />
+      <None Remove="TestFiles\Valid_Hourly_CIM_TimeSeries_WithQuantityMissingFirstPosition.xml" />
       <None Remove="TestFiles\Valid_Hourly_CIM_TimeSeries_WithUnusedCimContent.xml" />
     </ItemGroup>
 
     <ItemGroup>
+      <EmbeddedResource Include="TestFiles\Valid_Hourly_CIM_TimeSeries_WithQuantityMissingFirstPosition.xml" />
       <EmbeddedResource Include="TestFiles\Valid_Hourly_CIM_TimeSeries_WithoutQualityElements.xml" />
       <EmbeddedResource Include="TestFiles\Valid_Hourly_CIM_TimeSeries_WithUnusedCimContent.xml" />
       <EmbeddedResource Include="TestFiles\Valid_Hourly_CIM_TimeSeries.xml" />

--- a/source/GreenEnergyHub.TimeSeries/source/GreenEnergyHub.TimeSeries.Tests/Infrastructure/Messaging/Serialization/Commands/QualityMapperTests.cs
+++ b/source/GreenEnergyHub.TimeSeries/source/GreenEnergyHub.TimeSeries.Tests/Infrastructure/Messaging/Serialization/Commands/QualityMapperTests.cs
@@ -20,20 +20,20 @@ using Xunit.Categories;
 namespace GreenEnergyHub.TimeSeries.Tests.Infrastructure.Messaging.Serialization.Commands
 {
     [UnitTest]
-    public class QuantityQualityMapperTests
+    public class QualityMapperTests
     {
         [Theory]
-        [InlineData("D01", QuantityQuality.Calculated)]
-        [InlineData("56", QuantityQuality.Estimated)]
-        [InlineData("E01", QuantityQuality.Measured)]
-        [InlineData("D99", QuantityQuality.QuantityMissing)]
-        [InlineData("36", QuantityQuality.Revised)]
-        [InlineData("", QuantityQuality.Unknown)]
-        [InlineData("DoesNotExist", QuantityQuality.Unknown)]
-        [InlineData(null, QuantityQuality.Unknown)]
-        public void Map_WhenGivenInput_MapsToCorrectEnum(string input, QuantityQuality expected)
+        [InlineData("D01", Quality.Calculated)]
+        [InlineData("56", Quality.Estimated)]
+        [InlineData("E01", Quality.Measured)]
+        [InlineData("A02", Quality.QuantityMissing)]
+        [InlineData("36", Quality.Revised)]
+        [InlineData("", Quality.Unknown)]
+        [InlineData("DoesNotExist", Quality.Unknown)]
+        [InlineData(null, Quality.Unknown)]
+        public void Map_WhenGivenInput_MapsToCorrectEnum(string input, Quality expected)
         {
-            var actual = QuantityQualityMapper.Map(input);
+            var actual = QualityMapper.Map(input);
             Assert.Equal(actual, expected);
         }
     }

--- a/source/GreenEnergyHub.TimeSeries/source/GreenEnergyHub.TimeSeries.Tests/Infrastructure/Messaging/Serialization/Commands/TimeSeriesCommandConverterTests.cs
+++ b/source/GreenEnergyHub.TimeSeries/source/GreenEnergyHub.TimeSeries.Tests/Infrastructure/Messaging/Serialization/Commands/TimeSeriesCommandConverterTests.cs
@@ -82,7 +82,59 @@ namespace GreenEnergyHub.TimeSeries.Tests.Infrastructure.Messaging.Serialization
             Assert.Equal(1, result.Series.Points[0].Position);
             Assert.Equal(0.337m, result.Series.Points[0].Quantity);
             Assert.Equal(InstantPattern.ExtendedIso.Parse("2021-06-27T22:00:00Z").Value, result.Series.Points[0].ObservationDateTime);
-            Assert.Equal(QuantityQuality.Measured, result.Series.Points[0].Quality);
+            Assert.Equal(Quality.Measured, result.Series.Points[0].Quality);
+
+            await Task.CompletedTask.ConfigureAwait(false);
+        }
+
+        [Theory]
+        [InlineAutoMoqData]
+        public async Task ConvertAsync_WhenCalledWithValidTimeSeriesWithQuantityMissingFirstPosition_ReturnsParsedObject(
+            [NotNull][Frozen] Mock<ICorrelationContext> context,
+            [NotNull][Frozen] Mock<IIso8601Durations> iso8601Durations,
+            [NotNull] TimeSeriesCommandConverter timeSeriesCommandConverter)
+        {
+            // Arrange
+            var correlationId = Guid.NewGuid().ToString();
+            context.Setup(c => c.CorrelationId).Returns(correlationId);
+
+            SetObservationTime(iso8601Durations, "2021-06-27T22:00:00Z");
+
+            var stream = GetEmbeddedResource("GreenEnergyHub.TimeSeries.Tests.TestFiles.Valid_Hourly_CIM_TimeSeries_WithQuantityMissingFirstPosition.xml"); // change
+            using var reader = XmlReader.Create(stream, new XmlReaderSettings { Async = true });
+
+            // Act
+            var result = (TimeSeriesCommand)await timeSeriesCommandConverter.ConvertAsync(reader).ConfigureAwait(false);
+
+            // Assert
+            Assert.Equal(Quality.QuantityMissing, result.Series.Points[0].Quality);
+            Assert.Equal(Quality.Measured, result.Series.Points[1].Quality);
+
+            await Task.CompletedTask.ConfigureAwait(false);
+        }
+
+        [Theory]
+        [InlineAutoMoqData]
+        public async Task ConvertAsync_WhenCalledWithValidTimeSeriesWithoutQualityElements_ReturnsParsedObjectWithQualityMeasured(
+            [NotNull][Frozen] Mock<ICorrelationContext> context,
+            [NotNull][Frozen] Mock<IIso8601Durations> iso8601Durations,
+            [NotNull] TimeSeriesCommandConverter timeSeriesCommandConverter)
+        {
+            // Arrange
+            var correlationId = Guid.NewGuid().ToString();
+            context.Setup(c => c.CorrelationId).Returns(correlationId);
+
+            SetObservationTime(iso8601Durations, "2021-06-27T22:00:00Z");
+
+            var stream = GetEmbeddedResource("GreenEnergyHub.TimeSeries.Tests.TestFiles.Valid_Hourly_CIM_TimeSeries_WithoutQualityElements.xml");
+            using var reader = XmlReader.Create(stream, new XmlReaderSettings { Async = true });
+
+            // Act
+            var result = (TimeSeriesCommand)await timeSeriesCommandConverter.ConvertAsync(reader).ConfigureAwait(false);
+
+            // Assert
+            Assert.Equal(24, result.Series.Points.Count);
+            Assert.Equal(Quality.Measured, result.Series.Points[0].Quality);
 
             await Task.CompletedTask.ConfigureAwait(false);
         }
@@ -110,32 +162,6 @@ namespace GreenEnergyHub.TimeSeries.Tests.Infrastructure.Messaging.Serialization
             Assert.Equal("DocId_Valid_002", result.Document.Id);
             Assert.Equal("tId_Valid_002", result.Series.Id);
             Assert.Equal(24, result.Series.Points.Count);
-
-            await Task.CompletedTask.ConfigureAwait(false);
-        }
-
-        [Theory]
-        [InlineAutoMoqData]
-        public async Task ConvertAsync_WhenCalledWithValidTimeSeriesWithoutQualityElements_ReturnsParsedObjectWithQualityMeasured(
-            [NotNull][Frozen] Mock<ICorrelationContext> context,
-            [NotNull][Frozen] Mock<IIso8601Durations> iso8601Durations,
-            [NotNull] TimeSeriesCommandConverter timeSeriesCommandConverter)
-        {
-            // Arrange
-            var correlationId = Guid.NewGuid().ToString();
-            context.Setup(c => c.CorrelationId).Returns(correlationId);
-
-            SetObservationTime(iso8601Durations, "2021-06-27T22:00:00Z");
-
-            var stream = GetEmbeddedResource("GreenEnergyHub.TimeSeries.Tests.TestFiles.Valid_Hourly_CIM_TimeSeries_WithoutQualityElements.xml");
-            using var reader = XmlReader.Create(stream, new XmlReaderSettings { Async = true });
-
-            // Act
-            var result = (TimeSeriesCommand)await timeSeriesCommandConverter.ConvertAsync(reader).ConfigureAwait(false);
-
-            // Assert
-            Assert.Equal(24, result.Series.Points.Count);
-            Assert.Equal(QuantityQuality.Measured, result.Series.Points[0].Quality);
 
             await Task.CompletedTask.ConfigureAwait(false);
         }

--- a/source/GreenEnergyHub.TimeSeries/source/GreenEnergyHub.TimeSeries.Tests/Infrastructure/Messaging/Serialization/Commands/TimeSeriesCommandConverterTests.cs
+++ b/source/GreenEnergyHub.TimeSeries/source/GreenEnergyHub.TimeSeries.Tests/Infrastructure/Messaging/Serialization/Commands/TimeSeriesCommandConverterTests.cs
@@ -100,7 +100,7 @@ namespace GreenEnergyHub.TimeSeries.Tests.Infrastructure.Messaging.Serialization
 
             SetObservationTime(iso8601Durations, "2021-06-27T22:00:00Z");
 
-            var stream = GetEmbeddedResource("GreenEnergyHub.TimeSeries.Tests.TestFiles.Valid_Hourly_CIM_TimeSeries_WithQuantityMissingFirstPosition.xml"); // change
+            var stream = GetEmbeddedResource("GreenEnergyHub.TimeSeries.Tests.TestFiles.Valid_Hourly_CIM_TimeSeries_WithQuantityMissingFirstPosition.xml");
             using var reader = XmlReader.Create(stream, new XmlReaderSettings { Async = true });
 
             // Act

--- a/source/GreenEnergyHub.TimeSeries/source/GreenEnergyHub.TimeSeries.Tests/Infrastructure/Messaging/Serialization/Commands/TimeSeriesCommandConverterTests.cs
+++ b/source/GreenEnergyHub.TimeSeries/source/GreenEnergyHub.TimeSeries.Tests/Infrastructure/Messaging/Serialization/Commands/TimeSeriesCommandConverterTests.cs
@@ -72,7 +72,7 @@ namespace GreenEnergyHub.TimeSeries.Tests.Infrastructure.Messaging.Serialization
             Assert.Equal("578032999778756222", result.Series.MeteringPointId);
             Assert.Equal(MeteringPointType.Consumption, result.Series.MeteringPointType);
             Assert.Equal(SettlementMethod.Flex, result.Series.SettlementMethod);
-            // Registration...
+            Assert.Equal(InstantPattern.ExtendedIso.Parse("2021-06-21T10:23:40.150Z").Value, result.Series.RegistrationDateTime);
             Assert.Equal(MeasureUnit.KiloWattHour, result.Series.Unit);
             Assert.Equal(TimeSeriesResolution.Hour, result.Series.Resolution);
             Assert.Equal(InstantPattern.ExtendedIso.Parse("2021-06-27T22:00:00Z").Value, result.Series.StartDateTime);

--- a/source/GreenEnergyHub.TimeSeries/source/GreenEnergyHub.TimeSeries.Tests/TestFiles/Valid_Hourly_CIM_TimeSeries_WithQuantityMissingFirstPosition.xml
+++ b/source/GreenEnergyHub.TimeSeries/source/GreenEnergyHub.TimeSeries.Tests/TestFiles/Valid_Hourly_CIM_TimeSeries_WithQuantityMissingFirstPosition.xml
@@ -1,0 +1,162 @@
+﻿<!--
+Copyright 2020 Energinet DataHub A/S
+
+Licensed under the Apache License, Version 2.0 (the "License2");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<NotifyValidatedMeasureData_MarketDocument xmlns="urn:ebix:org:NotifyValidatedMeasureData:1:0">
+    <mRID>DocId_Valid_001</mRID>
+    <type>E66</type>
+    <process.processType>D42</process.processType>
+    <businessSector.type>23</businessSector.type>
+    <sender_MarketParticipant.mRID codingScheme="A01">8100000000030</sender_MarketParticipant.mRID>
+    <sender_MarketParticipant.marketRole.type>MDR</sender_MarketParticipant.marketRole.type>
+    <receiver_MarketParticipant.mRID codingScheme="A01">5790001330552</receiver_MarketParticipant.mRID>
+    <receiver_MarketParticipant.marketRole.type>EZ</receiver_MarketParticipant.marketRole.type>
+    <createdDateTime>2021-06-21T10:23:40.149Z</createdDateTime>
+    <Series>
+        <mRID>tId_Valid_001</mRID>
+        <marketEvaluationPoint.mRID>578032999778756222</marketEvaluationPoint.mRID>
+        <marketEvaluationPoint.type>E17</marketEvaluationPoint.type>
+        <marketEvaluationPoint.settlementMethod>D01</marketEvaluationPoint.settlementMethod>
+        <registration_DateAndOrTime.dateTime>2021-06-21T10:23:40.150Z</registration_DateAndOrTime.dateTime>
+        <product>8716867000030</product>
+        <measure_Unit.name>KWH</measure_Unit.name>
+        <Period>
+            <resolution>PT1H</resolution>
+            <timeInterval>
+                <start>2021-06-27T22:00:00Z</start>
+                <end>2021-06-28T22:00:00Z</end>
+            </timeInterval>
+            <Point>
+                <position>1</position>
+                <quantity>0</quantity>
+                <quality>A02</quality>
+            </Point>
+            <Point>
+                <position>2</position>
+                <quantity>1.683</quantity>
+                <quality>E01</quality>
+            </Point>
+            <Point>
+                <position>3</position>
+                <quantity>2.016</quantity>
+                <quality>E01</quality>
+            </Point>
+            <Point>
+                <position>4</position>
+                <quantity>3.895</quantity>
+                <quality>E01</quality>
+            </Point>
+            <Point>
+                <position>5</position>
+                <quantity>4.124</quantity>
+                <quality>E01</quality>
+            </Point>
+            <Point>
+                <position>6</position>
+                <quantity>5.754</quantity>
+                <quality>E01</quality>
+            </Point>
+            <Point>
+                <position>7</position>
+                <quantity>6.895</quantity>
+                <quality>E01</quality>
+            </Point>
+            <Point>
+                <position>8</position>
+                <quantity>7.895</quantity>
+                <quality>E01</quality>
+            </Point>
+            <Point>
+                <position>9</position>
+                <quantity>8.756</quantity>
+                <quality>E01</quality>
+            </Point>
+            <Point>
+                <position>10</position>
+                <quantity>9.002</quantity>
+                <quality>E01</quality>
+            </Point>
+            <Point>
+                <position>11</position>
+                <quantity>10.650</quantity>
+                <quality>E01</quality>
+            </Point>
+            <Point>
+                <position>12</position>
+                <quantity>11.248</quantity>
+                <quality>E01</quality>
+            </Point>
+            <Point>
+                <position>13</position>
+                <quantity>12.677</quantity>
+                <quality>E01</quality>
+            </Point>
+            <Point>
+                <position>14</position>
+                <quantity>13.845</quantity>
+                <quality>E01</quality>
+            </Point>
+            <Point>
+                <position>15</position>
+                <quantity>14.902</quantity>
+                <quality>E01</quality>
+            </Point>
+            <Point>
+                <position>16</position>
+                <quantity>15.379</quantity>
+                <quality>E01</quality>
+            </Point>
+            <Point>
+                <position>17</position>
+                <quantity>16.508</quantity>
+                <quality>E01</quality>
+            </Point>
+            <Point>
+                <position>18</position>
+                <quantity>17.657</quantity>
+                <quality>E01</quality>
+            </Point>
+            <Point>
+                <position>19</position>
+                <quantity>18.018</quantity>
+                <quality>E01</quality>
+            </Point>
+            <Point>
+                <position>20</position>
+                <quantity>19.019</quantity>
+                <quality>E01</quality>
+            </Point>
+            <Point>
+                <position>21</position>
+                <quantity>20.020</quantity>
+                <quality>E01</quality>
+            </Point>
+            <Point>
+                <position>22</position>
+                <quantity>21.021</quantity>
+                <quality>E01</quality>
+            </Point>
+            <Point>
+                <position>23</position>
+                <quantity>22.022</quantity>
+                <quality>E01</quality>
+            </Point>
+            <Point>
+                <position>24</position>
+                <quantity>23.023</quantity>
+                <quality>E01</quality>
+            </Point>
+        </Period>
+    </Series>
+</NotifyValidatedMeasureData_MarketDocument>


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-timeseries) before we can accept your contribution. --->

## Description

This PR does the following: 
- Make use of the correct quality code for quantity missing **A02**, replacing the fictive D99.
- Renaming QuantityQuality to Quality, adhering to the Timeseries domain language. 
- Adds another unit test to `TimeseriesCommandConverterTests.cs` that takes a valid CIM xml timeseries with quantity missing in the first position.

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

* #0000
