### PR TITLE
Fix missing token for SonarCloud pipeline

### DIFF
--- a/.github/workflows/sonarcloud-dotnet.yml
+++ b/.github/workflows/sonarcloud-dotnet.yml
@@ -18,6 +18,7 @@ env:
   DOTNET_VERSION: '5.0.x'
   SONAR_PROJECTKEY: 'geh-timeseries-dotnet'
   SOURCE_PATH_ON_BUILDMACHINE: 'D:\a\geh-timeseries\geh-timeseries\source' # We have to be speficic with this path to get around a .NET 5.0 issue in SonarCLoud
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 jobs:
   build:
     name: Build


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-timeseries) before we can accept your contribution. --->

## Description

The purpose of this PR is to add the token needed by SonarCloud which is currently missing and making our pipelines fail at random.

## References

