### PR TITLE
Upgrade Extensions.Logging.Abstractions to .NET 5

### DIFF
--- a/source/messaging/source/GreenEnergyHub.Messaging.Protobuf.Tests/GreenEnergyHub.Messaging.Protobuf.Tests.csproj
+++ b/source/messaging/source/GreenEnergyHub.Messaging.Protobuf.Tests/GreenEnergyHub.Messaging.Protobuf.Tests.csproj
@@ -34,7 +34,7 @@ limitations under the License.
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="5.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.1.10" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="5.0.0" />
     <PackageReference Include="Moq.AutoMock" Version="2.3.0" />
     <PackageReference Include="NodaTime" Version="3.0.5" />
     <PackageReference Include="NodaTime.Serialization.Protobuf" Version="2.0.0" />

--- a/source/messaging/source/GreenEnergyHub.Messaging.Tests/GreenEnergyHub.Messaging.Tests.csproj
+++ b/source/messaging/source/GreenEnergyHub.Messaging.Tests/GreenEnergyHub.Messaging.Tests.csproj
@@ -34,7 +34,7 @@ limitations under the License.
           <PrivateAssets>all</PrivateAssets>
         </PackageReference>
         <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="5.0.1" />
-        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.1.10" />
+        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="5.0.0" />
         <PackageReference Include="Moq" Version="4.16.0" />
         <PackageReference Include="Moq.AutoMock" Version="2.3.0" />
         <PackageReference Include="NodaTime" Version="3.0.5" />


### PR DESCRIPTION
In our earlier upgrade to .NET 5 in the Time Series domain, we missed upgrading Microsoft.Extensions.Logging.Abstractions, hence leaving the GreenEnergyHub.Messaging solution unbuildable, which this pull request makes up for.
