### PR TITLE
Fix: Change description for TimeSeriesId in contracts.md to "not unique"

### DIFF
--- a/docs/contracts.md
+++ b/docs/contracts.md
@@ -22,7 +22,7 @@ Represents an accepted time series, covering both originals as well as updates.
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| TimeSeriesId | string | required | A unique time series identifier |
+| TimeSeriesId | string | required | A time series identifier provided by the Market Participant. Uniqueness cannot be guaranteed |
 | MeteringPointId | string | required | A unique metering point identifier |
 | TimeSeriesStartDateTime | Timestamp | required | In UTC. The start of the time series period. The start equals the ObservationDateTime of the earliest point in the time series list |
 | TimeSeriesEndDateTime | Timestamp | required | In UTC. The end of the time series period. The end is to be considered an up to (excluding) date time which equals the end of the latest point in the time series list |


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-timeseries) before we can accept your contribution. --->

## Description

The contract for [TimeSeriesAccepted](https://github.com/Energinet-DataHub/geh-timeseries/blob/main/docs/contracts.md#timeseriesaccepted) incorrectly stated:
_"A unique time series identifier"_

This has been changed to
_"A time series identifier provided by the Market Participant. Uniqueness cannot be guaranteed"_

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

* #0000
