### PR TITLE
Generate Python classes from Protobuf contracts

### DIFF
--- a/.github/workflows/streaming-job.yml
+++ b/.github/workflows/streaming-job.yml
@@ -141,6 +141,7 @@ jobs:
         working-directory: ./source/streaming
         run: |
           echo "${{ steps.next-wheel-file-version.outputs.next_version }}" > VERSION
+          python -m pip install -e ./
           pip install wheel
           python setup.py sdist bdist_wheel
 

--- a/.github/workflows/streaming-job.yml
+++ b/.github/workflows/streaming-job.yml
@@ -141,6 +141,7 @@ jobs:
         working-directory: ./source/streaming
         run: |
           echo "${{ steps.next-wheel-file-version.outputs.next_version }}" > VERSION
+          # Generate Python classes from Protobuf contracts
           python -m pip install -e ./
           pip install wheel
           python setup.py sdist bdist_wheel


### PR DESCRIPTION
Python classes must be generated from protobuf contracts before wheel is built and distributed