### PR TITLE
Remove presumably unnecessary protobuf conda install

### DIFF
--- a/.github/actions/databricks-unit-test/Dockerfile
+++ b/.github/actions/databricks-unit-test/Dockerfile
@@ -4,7 +4,6 @@ RUN conda install --quiet --yes --satisfied-skip-solve \
     'rope=0.18.*' 'pytest=6.1.*' 'pylint=2.6.*' 'autopep8=1.5.*' 'configargparse=1.2.3' 'applicationinsights=0.11.9' 'coverage=5.3.*' \
     'pytest-mock=3.5.*' \
     && \
-    conda install --quiet --yes --satisfied-skip-solve -c anaconda 'protobuf=3.*' && \
     pip --no-cache-dir install protodf && \
     conda clean --all -f -y && \
     fix-permissions "${CONDA_DIR}" && \

--- a/.github/actions/databricks-unit-test/Dockerfile
+++ b/.github/actions/databricks-unit-test/Dockerfile
@@ -4,7 +4,6 @@ RUN conda install --quiet --yes --satisfied-skip-solve \
     'rope=0.18.*' 'pytest=6.1.*' 'pylint=2.6.*' 'autopep8=1.5.*' 'configargparse=1.2.3' 'applicationinsights=0.11.9' 'coverage=5.3.*' \
     'pytest-mock=3.5.*' \
     && \
-    pip --no-cache-dir install protodf && \
     conda clean --all -f -y && \
     fix-permissions "${CONDA_DIR}" && \
     fix-permissions "/home/${NB_USER}"

--- a/.github/actions/databricks-unit-test/entrypoint.sh
+++ b/.github/actions/databricks-unit-test/entrypoint.sh
@@ -2,6 +2,8 @@
 
 cd ./source/streaming
 python setup.py install
+# Generate Python classes from ProtoBuf contracts
+python -m pip install -e ./
 # python coverage-threshold install
 pip install coverage-threshold
 coverage run --branch -m pytest tests/

--- a/.github/actions/databricks-unit-test/entrypoint.sh
+++ b/.github/actions/databricks-unit-test/entrypoint.sh
@@ -2,8 +2,6 @@
 
 cd ./source/streaming
 python setup.py install
-# Generate Python classes from ProtoBuf contracts
-python -m pip install -e ./
 # python coverage-threshold install
 pip install coverage-threshold
 coverage run --branch -m pytest tests/

--- a/.github/workflows/streaming-job.yml
+++ b/.github/workflows/streaming-job.yml
@@ -146,7 +146,6 @@ jobs:
           echo "${{ steps.next-wheel-file-version.outputs.next_version }}" > VERSION
           # Generate Python classes from Protobuf contracts
           python -m pip install -e ./
-          conda install --quiet --yes --satisfied-skip-solve -c anaconda 'protobuf=3.*'
           pip install wheel
           python setup.py sdist bdist_wheel
 


### PR DESCRIPTION
With this pull request, we remove infrastructure and deployment parts that are not necessary for the protobuf dependency.