### PR TITLE
Add global.json for both Time Series solutions

### DIFF
--- a/source/GreenEnergyHub.TimeSeries.Integration/global.json
+++ b/source/GreenEnergyHub.TimeSeries.Integration/global.json
@@ -1,0 +1,7 @@
+{
+  "sdk": {
+    "version": "5.0.403",
+    "rollForward": "latestPatch",
+    "allowPrerelease": false
+  }
+}

--- a/source/GreenEnergyHub.TimeSeries/global.json
+++ b/source/GreenEnergyHub.TimeSeries/global.json
@@ -1,0 +1,7 @@
+{
+  "sdk": {
+    "version": "5.0.403",
+    "rollForward": "latestPatch",
+    "allowPrerelease": false
+  }
+}


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-timeseries) before we can accept your contribution. --->

## Description

With the present pull request we introduce the global.json to pin the .Net Core SDK version used.

One global.json is enough to enforce dotnet to a pinned SDK version, but not all IDEs will conform to this version. Therefore a global.json is added for each .Net solution.

## References

* #305 