### PR TITLE
Feature/375 extend integration tests for timeseries domain

### DIFF
--- a/source/TimeSeries/MessageReceiver.IntegrationTests/Assets/Invalid_Hourly_CIM_TimeSeries_missing_mRID.xml
+++ b/source/TimeSeries/MessageReceiver.IntegrationTests/Assets/Invalid_Hourly_CIM_TimeSeries_missing_mRID.xml
@@ -1,0 +1,68 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright 2020 Energinet DataHub A/S
+
+Licensed under the Apache License, Version 2.0 (the "License2");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<cim:NotifyValidatedMeasureData_MarketDocument xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:cim="urn:ediel.org:measure:notifyvalidatedmeasuredata:0:1" xsi:schemaLocation="urn:ediel.org:measure:notifyvalidatedmeasuredata:0:1 urn-ediel-org-measure-notifyvalidatedmeasuredata-0-1.xsd">
+    <cim:type>E66</cim:type>
+    <cim:process.processType>E23</cim:process.processType>
+    <cim:businessSector.type>23</cim:businessSector.type>
+    <cim:sender_MarketParticipant.mRID codingScheme="A10">5799999933317</cim:sender_MarketParticipant.mRID>
+    <cim:sender_MarketParticipant.marketRole.type>MDR</cim:sender_MarketParticipant.marketRole.type>
+    <cim:receiver_MarketParticipant.mRID codingScheme="A10">5790001330552</cim:receiver_MarketParticipant.mRID>
+    <cim:receiver_MarketParticipant.marketRole.type>DGL</cim:receiver_MarketParticipant.marketRole.type>
+    <cim:createdDateTime>2022-12-17T09:30:47Z</cim:createdDateTime>
+    <cim:Series>
+        <cim:mRID>C1876456</cim:mRID>
+        <cim:originalTransactionIDReference_Series.mRID>C1875000</cim:originalTransactionIDReference_Series.mRID>
+        <cim:marketEvaluationPoint.mRID codingScheme="A10">579999993331812345</cim:marketEvaluationPoint.mRID>
+        <cim:marketEvaluationPoint.type>E17</cim:marketEvaluationPoint.type>
+        <cim:registration_DateAndOrTime.dateTime>2022-12-17T07:30:00Z</cim:registration_DateAndOrTime.dateTime>
+        <cim:product>8716867000030</cim:product>
+        <cim:quantity_Measure_Unit.name>KWH</cim:quantity_Measure_Unit.name>
+        <cim:Period>
+            <cim:resolution>PT1H</cim:resolution>
+            <cim:timeInterval>
+                <cim:start>2022-08-15T22:00Z</cim:start>
+                <cim:end>2022-08-15T04:00Z</cim:end>
+            </cim:timeInterval>
+            <cim:Point>
+                <cim:position>1</cim:position>
+                <cim:quantity>242</cim:quantity>
+                <cim:quality>A03</cim:quality>
+            </cim:Point>
+            <cim:Point>
+                <cim:position>2</cim:position>
+                <cim:quantity>242</cim:quantity>
+            </cim:Point>
+            <cim:Point>
+                <cim:position>3</cim:position>
+                <cim:quantity>222</cim:quantity>
+            </cim:Point>
+            <cim:Point>
+                <cim:position>4</cim:position>
+                <cim:quantity>202</cim:quantity>
+            </cim:Point>
+            <cim:Point>
+                <cim:position>5</cim:position>
+                <cim:quantity>191</cim:quantity>
+                <cim:quality>A05</cim:quality>
+            </cim:Point>
+            <cim:Point>
+                <cim:position>6</cim:position>
+                <cim:quality>A02</cim:quality>
+            </cim:Point>
+        </cim:Period>
+    </cim:Series>
+</cim:NotifyValidatedMeasureData_MarketDocument>

--- a/source/TimeSeries/MessageReceiver.IntegrationTests/Assets/TestDocuments.cs
+++ b/source/TimeSeries/MessageReceiver.IntegrationTests/Assets/TestDocuments.cs
@@ -20,6 +20,8 @@ namespace Energinet.DataHub.TimeSeries.MessageReceiver.IntegrationTests.Assets
     {
         public string ValidTimeSeries => GetDocumentAsString("Valid_Hourly_CIM_TimeSeries.xml");
 
+        public string InvalidTimeSeries => GetDocumentAsString("Invalid_Hourly_CIM_TimeSeries_missing_mRID.xml");
+
         private string GetDocumentAsString(string documentName)
         {
             var stream = GetDocumentStream(documentName);

--- a/source/TimeSeries/MessageReceiver.IntegrationTests/Assets/TestDocuments.cs
+++ b/source/TimeSeries/MessageReceiver.IntegrationTests/Assets/TestDocuments.cs
@@ -20,7 +20,7 @@ namespace Energinet.DataHub.TimeSeries.MessageReceiver.IntegrationTests.Assets
     {
         public string ValidTimeSeries => GetDocumentAsString("Valid_Hourly_CIM_TimeSeries.xml");
 
-        public string InvalidTimeSeries => GetDocumentAsString("Invalid_Hourly_CIM_TimeSeries_missing_mRID.xml");
+        public string InvalidTimeSeriesMissingId => GetDocumentAsString("Invalid_Hourly_CIM_TimeSeries_missing_mRID.xml");
 
         private string GetDocumentAsString(string documentName)
         {

--- a/source/TimeSeries/MessageReceiver.IntegrationTests/Fixtures/TimeSeriesFunctionAppFixture.cs
+++ b/source/TimeSeries/MessageReceiver.IntegrationTests/Fixtures/TimeSeriesFunctionAppFixture.cs
@@ -36,6 +36,8 @@ namespace Energinet.DataHub.TimeSeries.MessageReceiver.IntegrationTests.Fixtures
 
         public AuthorizationConfiguration AuthorizationConfiguration { get; }
 
+        public BlobContainerClient ContainerClient { get; private set; }
+
         private IntegrationTestConfiguration IntegrationTestConfiguration { get; }
 
         private AzuriteManager AzuriteManager { get; }
@@ -61,8 +63,8 @@ namespace Energinet.DataHub.TimeSeries.MessageReceiver.IntegrationTests.Fixtures
             AzuriteManager.StartAzurite();
 
             // Shared logging blob storage container
-            var storage = new BlobContainerClient("UseDevelopmentStorage=true", "marketoplogs");
-            await storage.CreateIfNotExistsAsync().ConfigureAwait(false);
+            ContainerClient = new BlobContainerClient("UseDevelopmentStorage=true", "marketoplogs");
+            await ContainerClient.CreateIfNotExistsAsync().ConfigureAwait(false);
         }
 
         /// <inheritdoc/>

--- a/source/TimeSeries/MessageReceiver.IntegrationTests/Fixtures/TimeSeriesFunctionAppFixture.cs
+++ b/source/TimeSeries/MessageReceiver.IntegrationTests/Fixtures/TimeSeriesFunctionAppFixture.cs
@@ -36,7 +36,7 @@ namespace Energinet.DataHub.TimeSeries.MessageReceiver.IntegrationTests.Fixtures
 
         public AuthorizationConfiguration AuthorizationConfiguration { get; }
 
-        public BlobContainerClient ContainerClient { get; private set; }
+        public BlobContainerClient LogContainerClient { get; private set; }
 
         private IntegrationTestConfiguration IntegrationTestConfiguration { get; }
 
@@ -63,8 +63,8 @@ namespace Energinet.DataHub.TimeSeries.MessageReceiver.IntegrationTests.Fixtures
             AzuriteManager.StartAzurite();
 
             // Shared logging blob storage container
-            ContainerClient = new BlobContainerClient("UseDevelopmentStorage=true", "marketoplogs");
-            await ContainerClient.CreateIfNotExistsAsync().ConfigureAwait(false);
+            LogContainerClient = new BlobContainerClient("UseDevelopmentStorage=true", "marketoplogs");
+            await LogContainerClient.CreateIfNotExistsAsync().ConfigureAwait(false);
         }
 
         /// <inheritdoc/>

--- a/source/TimeSeries/MessageReceiver.IntegrationTests/Functions/TimeSeriesTriggerTests.cs
+++ b/source/TimeSeries/MessageReceiver.IntegrationTests/Functions/TimeSeriesTriggerTests.cs
@@ -59,7 +59,7 @@ namespace Energinet.DataHub.TimeSeries.MessageReceiver.IntegrationTests.Function
         [Fact]
         public async Task When_RequestReceivedWithJwtTokenAndSchemaInvalid_Then_BadRequestResponseReturned()
         {
-            var content = _testDocuments.InvalidTimeSeries;
+            var content = _testDocuments.InvalidTimeSeriesMissingId;
             using var request = await CreateTimeSeriesHttpRequest(true, content).ConfigureAwait(false);
             var response = await Fixture.HostManager.HttpClient.SendAsync(request).ConfigureAwait(false);
             response.StatusCode.Should().Be(HttpStatusCode.BadRequest);

--- a/source/TimeSeries/MessageReceiver.IntegrationTests/Functions/TimeSeriesTriggerTests.cs
+++ b/source/TimeSeries/MessageReceiver.IntegrationTests/Functions/TimeSeriesTriggerTests.cs
@@ -77,7 +77,7 @@ namespace Energinet.DataHub.TimeSeries.MessageReceiver.IntegrationTests.Function
             using var request = await CreateTimeSeriesHttpRequest(true, content).ConfigureAwait(false);
 
             // Assert
-            var blobItems = Fixture.ContainerClient.GetBlobs().TakeLast(2).ToArray();
+            var blobItems = Fixture.LogContainerClient.GetBlobs().TakeLast(2).ToArray();
             var actualHttpDataRequestType = blobItems[0].Metadata["httpdatatype"];
             var actualHttpDataResponse = blobItems[1].Metadata["httpdatatype"];
             actualHttpDataRequestType.Should().Be(expectedHttpDataRequestType);

--- a/source/TimeSeries/MessageReceiver.IntegrationTests/MessageReceiver.IntegrationTests.csproj
+++ b/source/TimeSeries/MessageReceiver.IntegrationTests/MessageReceiver.IntegrationTests.csproj
@@ -39,6 +39,7 @@ limitations under the License.
   </ItemGroup>
   <ItemGroup>
     <None Remove="Assets\Valid_Hourly_CIM_TimeSeries.xml" />
+    <EmbeddedResource Include="Assets\Invalid_Hourly_CIM_TimeSeries_missing_mRID.xml" />
     <EmbeddedResource Include="Assets\Valid_Hourly_CIM_TimeSeries.xml" />
     <None Update="functionapphost.settings.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-timeseries) before we can accept your contribution. --->

## Description

This PR extends on the existing integration tests for timeserie ingestion with the following being covered
- [x] messages are logged
- [x] messages with invalid schema are rejected with an HTTP response of Bad Request

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

* #375 
