### PR TITLE
Remove PyLint because of license

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -70,7 +70,7 @@ WORKDIR $HOME
 #     && pipx reinstall-all
 
 RUN conda install --quiet --yes --satisfied-skip-solve \
-    'pyarrow=2.0.*' 'rope=0.18.*' 'pytest=6.1.*' 'pylint=2.6.*' 'autopep8=1.5.*' 'configargparse=1.2.3' 'applicationinsights=0.11.9' \
+    'pyarrow=2.0.*' 'rope=0.18.*' 'pytest=6.1.*' 'autopep8=1.5.*' 'configargparse=1.2.3' 'applicationinsights=0.11.9' \
     'coverage=5.3.*' 'azure-storage-blob=12.8.*' 'pytest-mock=3.5.*' \
     && \
     conda install --quiet --yes --satisfied-skip-solve -c anaconda 'protobuf=3.14.*' && \

--- a/NOTICE.md
+++ b/NOTICE.md
@@ -54,7 +54,6 @@ The Green Energy Hub repository relies on open source libraries and tools. We re
 | `protodf` | Current | <https://github.com/aroch/protobuf-dataframe/> | MIT |
 | `pyarrow` | 2.0.* | <https://pypi.org/project/pyarrow/2.0.0/> | Apache-2.0 |
 | `py4j` | 0.10.9 | <https://pypi.org/project/py4j/0.10.9/> | BSD |
-| `pylint` | 2.6.* | <https://pypi.org/project/pylint/2.6.2/> | GPL-2.0 |
 | `pytest` | 6.1.* | <https://pypi.org/project/pytest/6.1.2/> | MIT |
 | `pytest-cov` | 2.11.* | <https://pypi.org/project/pytest-cov/2.11.1> | MIT |
 | `pytest-mock` | 3.5.* | <https://pypi.org/project/pytest-mock/3.5.1/> | MIT |

--- a/wordlist.txt
+++ b/wordlist.txt
@@ -69,7 +69,6 @@ eventhub
 protobuf
 py
 pyarrow
-pylint
 pypi
 pyspelling
 servicebus


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-timeseries) before we can accept your contribution. --->

## Description

Remove Pylint because it does not have GPLv3 or above

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

* #611
