### PR TITLE
Removed CorrealtionId header

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ on:
 
 jobs:
   ci_base:
-    uses: Energinet-DataHub/.github/.github/workflows/ci-base.yml@5.0.0
+    uses: Energinet-DataHub/.github/.github/workflows/ci-base.yml@6.3.0
 
   dotnet_solution_time_series_ci:
     uses: Energinet-DataHub/.github/.github/workflows/dotnet-solution-ci.yml@5.0.0

--- a/source/TimeSeries/Infrastructure/Functions/HttpResponseBuilder.cs
+++ b/source/TimeSeries/Infrastructure/Functions/HttpResponseBuilder.cs
@@ -25,17 +25,9 @@ namespace Energinet.DataHub.TimeSeries.Infrastructure.Functions
 {
     public sealed class HttpResponseBuilder : IHttpResponseBuilder
     {
-        private readonly ICorrelationContext _correlationContext;
-
-        public HttpResponseBuilder(ICorrelationContext correlationContext)
-        {
-            _correlationContext = correlationContext;
-        }
-
         public HttpResponseData CreateAcceptedResponse(HttpRequestData request)
         {
             var httpResponseData = request.CreateResponse(HttpStatusCode.Accepted);
-            AddHeaders(httpResponseData);
             return httpResponseData;
         }
 
@@ -45,14 +37,8 @@ namespace Energinet.DataHub.TimeSeries.Infrastructure.Functions
         {
             var errorResponse = new ErrorResponse(schemaValidationErrors);
             var httpResponse = request.CreateResponse(HttpStatusCode.BadRequest);
-            AddHeaders(httpResponse);
             await errorResponse.WriteAsXmlAsync(httpResponse.Body).ConfigureAwait(false);
             return httpResponse;
-        }
-
-        private void AddHeaders(HttpResponseData httpResponseData)
-        {
-            httpResponseData.Headers.Add("CorrelationId", _correlationContext.Id);
         }
     }
 }

--- a/source/TimeSeries/IntegrationTests/TimeSeriesBundleIngestionEndpointTests.cs
+++ b/source/TimeSeries/IntegrationTests/TimeSeriesBundleIngestionEndpointTests.cs
@@ -58,7 +58,6 @@ namespace Energinet.DataHub.TimeSeries.MessageReceiver.IntegrationTests
             using var request = await CreateTimeSeriesHttpRequest(true, content).ConfigureAwait(false);
             var response = await Fixture.HostManager.HttpClient.SendAsync(request).ConfigureAwait(false);
             response.StatusCode.Should().Be(HttpStatusCode.Accepted);
-            response.Headers.Contains("CorrelationId").Should().BeTrue();
         }
 
         [Fact]


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-timeseries) before we can accept your contribution. --->

## Description

`CorrelationId` is now set as a header upon the incoming and outgoing message from APIM. So there is no longer a need for the specific domain to be setting the header.

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

* #0000
