### PR TITLE
Upgrade to .NET 6 and Functions v4

### DIFF
--- a/.github/actions/databricks-unit-test/Dockerfile
+++ b/.github/actions/databricks-unit-test/Dockerfile
@@ -1,0 +1,56 @@
+# Copyright 2020 Energinet DataHub A/S
+#
+# Licensed under the Apache License, Version 2.0 (the "License2");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM jupyter/pyspark-notebook:spark-3.1.2
+
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+COPY entrypoint.sh /entrypoint.sh
+
+USER root
+RUN chmod 777 /entrypoint.sh
+# This replaces the default spark configuration in the docker image with the ones defined in the sibling file
+COPY spark-defaults.conf $SPARK_HOME/conf/spark-defaults.conf
+
+
+# Install Azurite (support wasb-protocol storage for Delta tables in integration tests)
+RUN apt-get update; \
+    apt-get install -y npm && npm install -g n && n lts && hash -r && npm install -g azurite
+
+# Install ODBC drivers for pyodbc
+# See https://docs.microsoft.com/en-us/sql/connect/odbc/linux-mac/installing-the-microsoft-odbc-driver-for-sql-server?view=sql-server-ver15
+RUN apt-get update && apt-get install -y gnupg && apt-get install -y curl
+RUN curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add -
+RUN curl https://packages.microsoft.com/config/ubuntu/20.04/prod.list > /etc/apt/sources.list.d/mssql-release.list
+RUN apt-get update
+ENV ACCEPT_EULA=Y
+RUN apt-get install -y msodbcsql18 unixodbc-dev
+
+# Install spark packages with mamba
+RUN mamba install --quiet --yes --satisfied-skip-solve \
+    'pyarrow=2.0.*' 'rope=0.18.*' 'pytest=7.1.*' 'autopep8=1.5.*' 'configargparse=1.2.3'  \
+    'coverage=6.3.*' 'azure-storage-blob=12.8.*' 'pytest-mock=3.7.*'
+# Install python packages used in pyspark development
+RUN pip --no-cache-dir install pyspelling azure-eventhub coverage-threshold ptvsd azure-servicebus \
+    protodf delta-spark pytest-asyncio flake8 black dataclasses-json pyodbc
+# Below will make everything in the directory owned by the group ${NB_GID}
+RUN fix-permissions "${CONDA_DIR}"
+
+# Set misc environment variables required for properly run spark
+# note the amount of memory used on the driver is adjusted here
+ENV PATH=$SPARK_HOME/bin:$HADOOP_HOME/bin:$PATH \
+    PYTHONPATH="${SPARK_HOME}/python:${SPARK_HOME}/python/lib/py4j-0.10.9-src.zip" \
+    SPARK_OPTS="--driver-java-options=-Xms1024M --driver-java-options=-Xmx4096M --driver-java-options=-Dlog4j.logLevel=info"
+
+# Tell github action what it should run
+ENTRYPOINT ["/entrypoint.sh"]

--- a/.github/actions/databricks-unit-test/action.yml
+++ b/.github/actions/databricks-unit-test/action.yml
@@ -1,0 +1,19 @@
+# Copyright 2020 Energinet DataHub A/S
+#
+# Licensed under the Apache License, Version 2.0 (the "License2");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: 'PySpark execution'
+description: 'This action allows you to execute code, written for Spark, Databricks or other similar engines.'
+runs:
+  using: 'docker'
+  image: 'Dockerfile'

--- a/.github/actions/databricks-unit-test/entrypoint.sh
+++ b/.github/actions/databricks-unit-test/entrypoint.sh
@@ -1,0 +1,35 @@
+#!/bin/sh -l
+
+# Copyright 2020 Energinet DataHub A/S
+#
+# Licensed under the Apache License, Version 2.0 (the "License2");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Exit immediately with failure status if any command fails
+set -e
+cd source/databricks/tests/
+
+# There env vars are important to ensure that the driver and worker nodes in spark are alligned
+export PYSPARK_PYTHON=/opt/conda/bin/python
+export PYSPARK_DRIVER_PYTHON=/opt/conda/bin/python
+
+
+#Build wheel
+python ../setup.py install
+# python coverage-threshold install
+#pip install coverage-threshold delta-spark
+coverage run --branch -m pytest .
+# Create data for threshold evaluation
+coverage json
+# Create human reader friendly HTML report
+coverage html
+coverage-threshold --line-coverage-min 30

--- a/.github/actions/databricks-unit-test/spark-defaults.conf
+++ b/.github/actions/databricks-unit-test/spark-defaults.conf
@@ -1,0 +1,31 @@
+# Copyright 2020 Energinet DataHub A/S
+#
+# Licensed under the Apache License, Version 2.0 (the "License2");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Default system properties included when running spark-submit.
+# This is useful for setting default environmental settings.
+
+# Example:
+# spark.master                     spark://master:7077
+# spark.eventLog.enabled           true
+# spark.eventLog.dir               hdfs://namenode:8021/directory
+# spark.serializer                 org.apache.spark.serializer.KryoSerializer
+# spark.driver.memory               16g
+# spark.executor.extraJavaOptions  -XX:+PrintGCDetails -Dkey=value -Dnumbers="one two three"
+
+spark.jars.packages com.microsoft.azure:azure-eventhubs-spark_2.12:2.3.17,org.apache.hadoop:hadoop-azure:3.3.2,io.delta:delta-core_2.12:1.0.0,org.apache.hadoop:hadoop-common:3.3.2
+spark.sql.extensions io.delta.sql.DeltaSparkSessionExtension
+spark.sql.catalog.spark_catalog org.apache.spark.sql.delta.catalog.DeltaCatalog
+
+# spark.hadoop.fs.AbstractFileSystem.abfss.impl org.apache.hadoop.fs.azurebfs.Abfss
+# spark.hadoop.fs.abfss.impl org.apache.hadoop.fs.azurebfs.SecureAzureBlobFileSystem

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -35,10 +35,10 @@ jobs:
       ENVIRONMENT_REPOSITORY_PATH: ${{ secrets.ENVIRONMENT_REPOSITORY_PATH }}
 
   update_coverage_report_dotnet:
-    uses: Energinet-DataHub/.github/.github/workflows/dotnet-solution-ci.yml@6.0.1
+    uses: Energinet-DataHub/.github/.github/workflows/dotnet-solution-ci.yml@6.1.0
     with:
-      SOLUTION_FILE_PATH: "source/TimeSeries/TimeSeries.sln"
-      DOTNET_VERSION: "5.0.404"      
+      SOLUTION_FILE_PATH: 'source/TimeSeries/TimeSeries.sln'
+      DOTNET_VERSION: '6.0.201'
       USE_AZURE_FUNCTIONS_TOOLS: true
     secrets:
       AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -49,7 +49,7 @@ jobs:
       AZURE_SECRETS_KEYVAULT_URL: ${{ secrets.AZURE_SECRETS_KEYVAULT_URL }}
 
   update_coverage_report_python:
-    uses: Energinet-DataHub/.github/.github/workflows/python-ci-test-and-coverage.yml@6.0.1
+    uses: Energinet-DataHub/.github/.github/workflows/python-ci-test-and-coverage.yml@7.0.0
     with:
       PATH_STATIC_CHECKS: './source'
       IGNORE_ERRORS_AND_WARNING_FLAKE8: 'E501,F401,E402,W503,E122,E123,E126,F811'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
       AZURE_SECRETS_KEYVAULT_URL: ${{ secrets.AZURE_SECRETS_KEYVAULT_URL }}
 
   databricks_ci:
-    uses: Energinet-DataHub/.github/.github/workflows/python-ci-test-and-coverage.yml@6.1.3
+    uses: Energinet-DataHub/.github/.github/workflows/python-ci-test-and-coverage.yml@7.0.0
     with:
       PATH_STATIC_CHECKS: './source'
       IGNORE_ERRORS_AND_WARNING_FLAKE8: 'E501,F401,E402,W503,E122,E123,E126,F811'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,13 +20,13 @@ on:
 
 jobs:
   ci_base:
-    uses: Energinet-DataHub/.github/.github/workflows/ci-base.yml@6.3.0
+    uses: Energinet-DataHub/.github/.github/workflows/ci-base.yml@6.2.0
 
   dotnet_solution_time_series_ci:
-    uses: Energinet-DataHub/.github/.github/workflows/dotnet-solution-ci.yml@5.0.0
+    uses: Energinet-DataHub/.github/.github/workflows/dotnet-solution-ci.yml@6.1.0
     with:
-      SOLUTION_FILE_PATH: "source/TimeSeries/TimeSeries.sln"
-      DOTNET_VERSION: "5.0.404"      
+      SOLUTION_FILE_PATH: 'source/TimeSeries/TimeSeries.sln'
+      DOTNET_VERSION: '6.0.201'
       USE_AZURE_FUNCTIONS_TOOLS: true
     secrets:
       AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
@@ -48,7 +48,7 @@ jobs:
     with:
       TERRAFORM_WORKING_DIR_PATH: "./build/primary/main"
       TERRAFORM_VERSION: "1.1.6"
-      
+
   terraform_validate_streaming_cluster:
     uses: Energinet-DataHub/.github/.github/workflows/terraform-validate.yml@2.6.1
     with:
@@ -57,10 +57,10 @@ jobs:
 
   time_series_bundle_ingestor_ci:
     needs: [ci_base, terraform_validate]
-    uses: Energinet-DataHub/.github/.github/workflows/dotnet-create-function-artifact.yml@5.0.0
+    uses: Energinet-DataHub/.github/.github/workflows/dotnet-create-function-artifact.yml@6.1.0
     with:
-      CSPROJ_FILE_PATH: "source/TimeSeries/TimeSeriesBundleIngestor/TimeSeriesBundleIngestor.csproj"
-      DOTNET_VERSION: "5.0.404"
+      CSPROJ_FILE_PATH: 'source/TimeSeries/TimeSeriesBundleIngestor/TimeSeriesBundleIngestor.csproj'
+      DOTNET_VERSION: '6.0.201'
       ARTIFACT_NAME: time_series_bundle_ingestor
 
   wheel_ci:
@@ -80,4 +80,4 @@ jobs:
     with:
       CALLER_REPOSITORY_PATH: Energinet-DataHub/geh-timeseries
     secrets:
-      PAT_TOKEN: ${{ secrets.PAT_TOKEN }}
+      PAT_TOKEN: ${{ secrets.PAT_TOKEN }}

--- a/build/primary/main/func-time-series-bundle-ingestor.tf
+++ b/build/primary/main/func-time-series-bundle-ingestor.tf
@@ -21,7 +21,7 @@ module "time_series_bundle_ingestor" {
   resource_group_name                       = azurerm_resource_group.this.name
   location                                  = azurerm_resource_group.this.location
   app_service_plan_id                       = data.azurerm_key_vault_secret.plan_shared_id.value
-  application_insights_instrumentation_key  = data.azurerm_key_vault_secret.appi_instrumentation_key.value
+  application_insights_instrumentation_key  = data.azurerm_key_vault_secret.appi_shared_instrumentation_key.value
   always_on                                 = true
   health_check_path                         = "/api/monitor/ready"
   health_check_alert_action_group_id        = data.azurerm_key_vault_secret.primary_action_group_id.value
@@ -40,6 +40,6 @@ module "time_series_bundle_ingestor" {
     EVENT_HUB_CONNECTION_STRING                         = module.evh_received_timeseries.primary_connection_strings["send"]
     EVENT_HUB_NAME                                      = module.evh_received_timeseries.name
   }
-  
+
   tags                                      = azurerm_resource_group.this.tags
 }

--- a/build/primary/main/func-time-series-bundle-ingestor.tf
+++ b/build/primary/main/func-time-series-bundle-ingestor.tf
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 module "time_series_bundle_ingestor" {
-  source                                    = "git::https://github.com/Energinet-DataHub/geh-terraform-modules.git//azure/function-app?ref=5.8.0"
+  source                                    = "git::https://github.com/Energinet-DataHub/geh-terraform-modules.git//azure/function-app?ref=5.12.0"
 
   name                                      = "time-series-bundle-ingestor"
   project_name                              = var.domain_name_short
@@ -22,6 +22,7 @@ module "time_series_bundle_ingestor" {
   location                                  = azurerm_resource_group.this.location
   app_service_plan_id                       = data.azurerm_key_vault_secret.plan_shared_id.value
   application_insights_instrumentation_key  = data.azurerm_key_vault_secret.appi_shared_instrumentation_key.value
+  log_analytics_workspace_id                = data.azurerm_key_vault_secret.log_shared_id.value
   always_on                                 = true
   health_check_path                         = "/api/monitor/ready"
   health_check_alert_action_group_id        = data.azurerm_key_vault_secret.primary_action_group_id.value

--- a/build/primary/main/kv-shared-resources.tf
+++ b/build/primary/main/kv-shared-resources.tf
@@ -16,7 +16,7 @@ data "azurerm_key_vault" "kv_shared_resources" {
   resource_group_name = var.shared_resources_resource_group_name
 }
 
-data "azurerm_key_vault_secret" "appi_instrumentation_key" {
+data "azurerm_key_vault_secret" "appi_shared_instrumentation_key" {
   name         = "appi-shared-instrumentation-key"
   key_vault_id = data.azurerm_key_vault.kv_shared_resources.id
 }

--- a/build/primary/main/kv-shared-resources.tf
+++ b/build/primary/main/kv-shared-resources.tf
@@ -55,7 +55,13 @@ data "azurerm_key_vault_secret" "plan_shared_id" {
   name         = "plan-shared-id"
   key_vault_id = data.azurerm_key_vault.kv_shared_resources.id
 }
+
 data "azurerm_key_vault_secret" "primary_action_group_id" {
   name         = "ag-primary-id"
+  key_vault_id = data.azurerm_key_vault.kv_shared_resources.id
+}
+
+data "azurerm_key_vault_secret" "log_shared_id" {
+  name         = "log-shared-id"
   key_vault_id = data.azurerm_key_vault.kv_shared_resources.id
 }

--- a/source/.editorconfig
+++ b/source/.editorconfig
@@ -270,7 +270,10 @@ csharp_space_between_square_brackets = false
 csharp_preserve_single_line_statements = false
 csharp_preserve_single_line_blocks = true
 
-# Analyzers/StyleCop rules
+###############################
+# .NET Analyzers              #
+###############################
+
 dotnet_diagnostic.CA1303.severity = suggestion
 dotnet_diagnostic.CA1715.severity = error
 dotnet_diagnostic.CA1001.severity = warning
@@ -337,6 +340,13 @@ dotnet_diagnostic.CA2240.severity = warning
 dotnet_diagnostic.CA2241.severity = warning
 dotnet_diagnostic.CA2242.severity = warning
 dotnet_diagnostic.CS1591.severity = none
+
+###############################
+# StyleCop Analyzers          #
+###############################
+
+# See rules here: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/tree/master/documentation
+
 dotnet_diagnostic.SA0001.severity = none
 dotnet_diagnostic.SA1000.severity = error
 dotnet_diagnostic.SA1001.severity = error

--- a/source/.editorconfig
+++ b/source/.editorconfig
@@ -517,3 +517,12 @@ dotnet_diagnostic.SA1651.severity = error
 dotnet_diagnostic.SA1652.severity = none
 dotnet_diagnostic.SX1101.severity = error
 dotnet_diagnostic.SX1309.severity = error
+
+###############################
+# Code Style rules (IDE)      #
+###############################
+
+# See rules here: https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/
+
+# IDE0079: Remove unnecessary suppression
+dotnet_diagnostic.IDE0079.severity = warning

--- a/source/Directory.Build.props
+++ b/source/Directory.Build.props
@@ -10,10 +10,18 @@
     See also: https://docs.microsoft.com/en-us/visualstudio/msbuild/customize-your-build?view=vs-2019#search-scope
     -->
     <ItemGroup>
-        <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="16.8.55" />
-        <PackageReference Include="StyleCop.Analyzers" Version="1.1.118" />
-        <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.2" />
-        <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.3.1" />
+        <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.1.46">
+          <PrivateAssets>all</PrivateAssets>
+          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+        <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.354">
+          <PrivateAssets>all</PrivateAssets>
+          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+        <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="6.0.0">
+          <PrivateAssets>all</PrivateAssets>
+          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
 
         <!--
         Additional settings for specific rules (e.g. SA1200 specify namespaces must be placed correctly, the json file then defines what "correctly" means)

--- a/source/TimeSeries/Application/Application.csproj
+++ b/source/TimeSeries/Application/Application.csproj
@@ -16,7 +16,7 @@ limitations under the License.
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <AssemblyName>Energinet.DataHub.TimeSeries.Application</AssemblyName>
     <RootNamespace>Energinet.DataHub.TimeSeries.Application</RootNamespace>
   </PropertyGroup>

--- a/source/TimeSeries/Infrastructure/Infrastructure.csproj
+++ b/source/TimeSeries/Infrastructure/Infrastructure.csproj
@@ -16,7 +16,7 @@ limitations under the License.
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <AssemblyName>Energinet.DataHub.TimeSeries.Infrastructure</AssemblyName>
     <RootNamespace>Energinet.DataHub.TimeSeries.Infrastructure</RootNamespace>
   </PropertyGroup>

--- a/source/TimeSeries/IntegrationTests/Fixtures/TimeSeriesFunctionAppFixture.cs
+++ b/source/TimeSeries/IntegrationTests/Fixtures/TimeSeriesFunctionAppFixture.cs
@@ -61,7 +61,7 @@ namespace Energinet.DataHub.TimeSeries.MessageReceiver.IntegrationTests.Fixtures
             }
 
             var buildConfiguration = GetBuildConfiguration();
-            hostSettings.FunctionApplicationPath = $"..\\..\\..\\..\\TimeSeriesBundleIngestor\\bin\\{buildConfiguration}\\net5.0";
+            hostSettings.FunctionApplicationPath = $"..\\..\\..\\..\\TimeSeriesBundleIngestor\\bin\\{buildConfiguration}\\net6.0";
 
             // The log message we expect in the host log when the host is started and ready to server.
             hostSettings.HostStartedEvent = "Worker process started and initialized";

--- a/source/TimeSeries/IntegrationTests/IntegrationTests.csproj
+++ b/source/TimeSeries/IntegrationTests/IntegrationTests.csproj
@@ -1,4 +1,4 @@
-<!--
+﻿<!--
 Copyright 2020 Energinet DataHub A/S
 
 Licensed under the Apache License, Version 2.0 (the "License2");
@@ -15,7 +15,7 @@ limitations under the License.
 -->
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
     <AssemblyName>Energinet.DataHub.TimeSeries.MessageReceiver.IntegrationTests</AssemblyName>

--- a/source/TimeSeries/IntegrationTests/IntegrationTests.csproj
+++ b/source/TimeSeries/IntegrationTests/IntegrationTests.csproj
@@ -24,7 +24,7 @@ limitations under the License.
   <ItemGroup>
     <PackageReference Include="Energinet.DataHub.Core.FunctionApp.TestCommon" Version="1.3.0" />
     <PackageReference Include="Energinet.DataHub.Core.JsonSerialization" Version="1.0.0" />
-    <PackageReference Include="FluentAssertions" Version="6.3.0" />
+    <PackageReference Include="FluentAssertions" Version="6.5.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">

--- a/source/TimeSeries/IntegrationTests/TimeSeriesBundleIngestionEndpointTests.cs
+++ b/source/TimeSeries/IntegrationTests/TimeSeriesBundleIngestionEndpointTests.cs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
@@ -70,6 +71,7 @@ namespace Energinet.DataHub.TimeSeries.MessageReceiver.IntegrationTests
         }
 
         [Fact]
+        [SuppressMessage("Usage", "VSTHRD103:Call async methods when in an async method", Justification = "TODO: Fix analyzer warning")]
         public async Task When_RequestIsReceived_Then_RequestAndResponseAreLogged()
         {
             // Arrange

--- a/source/TimeSeries/TestCore/Assets/TestDocuments.cs
+++ b/source/TimeSeries/TestCore/Assets/TestDocuments.cs
@@ -43,7 +43,7 @@ namespace Energinet.DataHub.TimeSeries.TestCore.Assets
         {
             var rootNamespace = GetType().Namespace;
             var assembly = GetType().Assembly;
-            return assembly.GetManifestResourceStream($"{rootNamespace}.{documentName}") !;
+            return assembly.GetManifestResourceStream($"{rootNamespace}.{documentName}")!;
         }
     }
 }

--- a/source/TimeSeries/TestCore/TestCore.csproj
+++ b/source/TimeSeries/TestCore/TestCore.csproj
@@ -16,7 +16,7 @@ limitations under the License.
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <AssemblyName>Energinet.DataHub.TimeSeries.TestCore</AssemblyName>
     <RootNamespace>Energinet.DataHub.TimeSeries.TestCore</RootNamespace>
   </PropertyGroup>

--- a/source/TimeSeries/TimeSeriesBundleIngestor/TimeSeriesBundleIngestor.csproj
+++ b/source/TimeSeries/TimeSeriesBundleIngestor/TimeSeriesBundleIngestor.csproj
@@ -15,8 +15,8 @@ limitations under the License.
 -->
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
-    <AzureFunctionsVersion>V3</AzureFunctionsVersion>
+    <TargetFramework>net6.0</TargetFramework>
+    <AzureFunctionsVersion>V4</AzureFunctionsVersion>
     <OutputType>Exe</OutputType>
     <AssemblyName>Energinet.DataHub.TimeSeries.MessageReceiver</AssemblyName>
     <RootNamespace>Energinet.DataHub.TimeSeries.MessageReceiver</RootNamespace>

--- a/source/TimeSeries/UnitTests/UnitTests.csproj
+++ b/source/TimeSeries/UnitTests/UnitTests.csproj
@@ -1,4 +1,4 @@
-<!--
+﻿<!--
 Copyright 2020 Energinet DataHub A/S
 
 Licensed under the Apache License, Version 2.0 (the "License2");
@@ -16,7 +16,7 @@ limitations under the License.
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <AssemblyName>Energinet.DataHub.TimeSeries.UnitTests</AssemblyName>
     <RootNamespace>Energinet.DataHub.TimeSeries.UnitTests</RootNamespace>
   </PropertyGroup>


### PR DESCRIPTION
## Description

Upgrade Time Series to .NET 6 and function v4.

Important:
* Focus is on upgrading to .NET 6 and functions v4. Only NuGet packages directly impacted by this (e.g. Analyzers) has been updated.

## References

https://app.zenhub.com/workspaces/mighty-ducks---the-outlaws-6193fe815d79fc0011e741b1/issues/energinet-datahub/the-outlaws/257
