### PR TITLE
Remove DOTNET_VERSION

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -38,7 +38,6 @@ jobs:
     uses: Energinet-DataHub/.github/.github/workflows/dotnet-solution-ci.yml@7.7.0
     with:
       SOLUTION_FILE_PATH: 'source/TimeSeries/TimeSeries.sln'
-      DOTNET_VERSION: '6.0.301'
       USE_AZURE_FUNCTIONS_TOOLS: true
     secrets:
       AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,6 @@ jobs:
     uses: Energinet-DataHub/.github/.github/workflows/dotnet-solution-ci.yml@7.7.0
     with:
       SOLUTION_FILE_PATH: 'source/TimeSeries/TimeSeries.sln'
-      DOTNET_VERSION: '6.0.301'
       USE_AZURE_FUNCTIONS_TOOLS: true
       PREPARE_OUTPUTS: true
     secrets:


### PR DESCRIPTION
Speed up CI execution time by using default .NET Core SDK version pre-installed on hosted Github Runner

Reference: https://github.com/Energinet-DataHub/the-outlaws/issues/360