### PR TITLE
add storedtime

### DIFF
--- a/source/databricks/package/timeseries_persister.py
+++ b/source/databricks/package/timeseries_persister.py
@@ -14,7 +14,7 @@
 
 from pyspark.sql import SparkSession, DataFrame
 from pyspark.sql.types import StringType, StructType
-from pyspark.sql.functions import year, month, dayofmonth
+from pyspark.sql.functions import year, month, dayofmonth, current_timestamp
 from package.codelists import Colname
 
 
@@ -27,9 +27,10 @@ def process_raw_timeseries(df, epoch_id, time_series_unprocessed_path):
     """
 
     df = (
-        df.withColumn(Colname.year, year(df.CreatedDateTime))
-        .withColumn(Colname.month, month(df.CreatedDateTime))
-        .withColumn(Colname.day, dayofmonth(df.CreatedDateTime))
+        df.withColumn("storedTime", current_timestamp())
+        .withColumn(Colname.year, year("storedTime"))
+        .withColumn(Colname.month, month("storedTime"))
+        .withColumn(Colname.day, dayofmonth("storedTime"))
     )
 
     (


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-timeseries) before we can accept your contribution. --->

## Description
Adding storedTime of when data was stored in the parquet table. This is used for partitioning. And for filtering on time when we want to know how data looked at a specific time in history

## References

* #32
