### PR TITLE
Fix bad json file names

### DIFF
--- a/source/TimeSeries/Application/TimeSeriesForwarder.cs
+++ b/source/TimeSeries/Application/TimeSeriesForwarder.cs
@@ -47,7 +47,7 @@ namespace Energinet.DataHub.TimeSeries.Application
         public async Task HandleAsync(TimeSeriesBundleDto timeSeriesBundle)
         {
             var folder = _timeSeriesRawFolderOptions.FolderName;
-            var blobName = $"{folder}/actor={timeSeriesBundle.Document.Sender.Id}-document={timeSeriesBundle.Document.Id}.json";
+            var blobName = $"{folder}/actor-{timeSeriesBundle.Document.Sender.Id}-document-{timeSeriesBundle.Document.Id}.json";
             await using var outputStream = await _rawTimeSeriesStorageClient.OpenWriteAsync(blobName);
             await _timeSeriesBundleConverter.ConvertAsync(timeSeriesBundle, outputStream);
 

--- a/source/TimeSeries/IntegrationTests/TimeSeriesBundleIngestionEndpointTests.cs
+++ b/source/TimeSeries/IntegrationTests/TimeSeriesBundleIngestionEndpointTests.cs
@@ -71,7 +71,7 @@ namespace Energinet.DataHub.TimeSeries.IntegrationTests
             // Arrange
             var baseFileName = Guid.NewGuid().ToString();
             var senderMarketParticipantId = "5799999933317";
-            var blobName = $"timeseries-raw/actor={senderMarketParticipantId}-document={baseFileName}.json";
+            var blobName = $"timeseries-raw/actor-{senderMarketParticipantId}-document-{baseFileName}.json";
             var expected = _testDocuments.TimeSeriesBundleJsonAsStringWithGuid(baseFileName);
             var content = _testDocuments.ValidMultipleTimeSeriesAsStringWithGuid(baseFileName);
             using var request = await CreateTimeSeriesHttpRequest(true, content).ConfigureAwait(false);


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-timeseries) before we can accept your contribution. --->

## Description

The chosen json file names caused this problem in Spark:

```
22/08/08 09:25:46 ERROR MicroBatchExecution: Query [id = bf35b7dc-5955-4dfd-b5fc-0ff0a9dde5e5, runId = 5c966487-5696-4643-93c6-e37c836e1247] terminated with error
java.lang.IllegalArgumentException: java.net.URISyntaxException: Relative path in absolute URI: actor=8200000007739-document=DocId2022-08-08T09:22:20.459Z.json
	at org.apache.hadoop.fs.Path.initialize(Path.java:263)
```
<!--- Please leave a helpful description of the pull request here. --->

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

* https://github.com/Energinet-DataHub/opengeh-wholesale/issues/32
