### PR TITLE
pack: Energinet.DataHub.Core.Schemas Version=2.1

### DIFF
--- a/source/TimeSeries/TimeSeriesBundleIngestor/TimeSeriesBundleIngestor.csproj
+++ b/source/TimeSeries/TimeSeriesBundleIngestor/TimeSeriesBundleIngestor.csproj
@@ -30,7 +30,7 @@ limitations under the License.
     <PackageReference Include="Energinet.DataHub.Core.FunctionApp.Common.Abstractions" Version="1.0.3" />
     <PackageReference Include="Energinet.DataHub.Core.JsonSerialization" Version="1.0.0" />
     <PackageReference Include="Energinet.DataHub.Core.Logging" Version="1.2.1" />
-    <PackageReference Include="Energinet.DataHub.Core.Schemas" Version="1.0.8" />
+    <PackageReference Include="Energinet.DataHub.Core.Schemas" Version="2.1.0" />
     <PackageReference Include="Energinet.DataHub.Core.SchemaValidation" Version="1.0.7" />
     <PackageReference Include="Microsoft.ApplicationInsights" Version="2.20.0" />
     <PackageReference Include="Microsoft.ApplicationInsights.WorkerService" Version="2.20.0" />


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/opengeh-wholesale) before we can accept your contribution. --->

## Description

An incident occurred because the schema used for validation did not support:
```
<marketEvaluationPoint.type>D17</marketEvaluationPoint.type>
<marketEvaluationPoint.type>D18</marketEvaluationPoint.type>
```
The updated package does.

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

[* #195 (in wholesale)](https://app.zenhub.com/workspaces/mandalorian-5fd22a1a59e4740018f5ab5a/issues/energinet-datahub/internal-repo/195)
