### PR TITLE
Use environment for OIDC

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -39,6 +39,7 @@ jobs:
     with:
       SOLUTION_FILE_PATH: 'source/TimeSeries/TimeSeries.sln'
       USE_AZURE_FUNCTIONS_TOOLS: true
+      ENVIRONMENT: AzureAuth
     secrets:
       AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
       AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,7 @@ jobs:
       SOLUTION_FILE_PATH: 'source/TimeSeries/TimeSeries.sln'
       USE_AZURE_FUNCTIONS_TOOLS: true
       PREPARE_OUTPUTS: true
+      ENVIRONMENT: AzureAuth
     secrets:
       AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
       AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}


### PR DESCRIPTION
## Description

Change federated credentials to use "environment" as "subject" when authenticating to Azure in workflows.

## References

https://app.zenhub.com/workspaces/mighty-ducks---the-outlaws-6193fe815d79fc0011e741b1/issues/energinet-datahub/the-outlaws/607