### PR TITLE
Notify if deployment dispatch failed

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -110,3 +110,22 @@ jobs:
           repository: '${{ secrets.ENVIRONMENT_REPOSITORY_PATH }}'
           event-type: 'timeseries-deployment-request-domain'
           client-payload: '{"domain_pr": "${{ steps.find_pull_request.outputs.pull_request_number }}", "databricks_deploy": "${{ needs.changes.outputs.databricks }}", "dotnet_deploy": "${{ needs.changes.outputs.dotnet }}"}'
+
+  #
+  # Send notification to teams channel if deployment dispatch failed
+  #
+
+  dispatch_failed:
+    needs: [
+      databricks_promote_prerelease,
+      dotnet_promote_prerelease
+      dispatch_deploment_event,
+    ]
+    if: |
+      always() &&
+      contains(needs.*.result, 'failure')
+    uses: Energinet-DataHub/.github/.github/workflows/notify-team.yml@v9
+    with:
+      TEAM_NAME: 'Mandalorian'
+      SUBJECT: 'Deployment dispatch failed: Timeseries'
+    secrets: inherit


### PR DESCRIPTION
Description
Notify teams in MS team channel if CD fails within domain repository.

References
https://app.zenhub.com/workspaces/mighty-ducks---the-outlaws-6193fe815d79fc0011e741b1/issues/energinet-datahub/the-outlaws/685